### PR TITLE
Longbridge real-time quotes, per-source refresh, and live push

### DIFF
--- a/Packages/PulseCore/Sources/PulseCore/Market/TradingCalendar.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Market/TradingCalendar.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public enum SessionState: String, Sendable {
     case closed, preMarket, regular, lunchBreak, postMarket
+    /// US overnight session (Sun 20:00 ET through Fri 04:00 ET, in nightly slices)
+    case overnight
 }
 
 /// Trading sessions per market (in each exchange's time zone).
@@ -12,9 +14,19 @@ public enum TradingCalendar {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = market.timeZone
         let comps = calendar.dateComponents([.weekday, .hour, .minute], from: date)
-        guard let weekday = comps.weekday, (2...6).contains(weekday),
-              let hour = comps.hour, let minute = comps.minute else { return .closed }
+        guard let weekday = comps.weekday, let hour = comps.hour, let minute = comps.minute else {
+            return .closed
+        }
         let m = hour * 60 + minute
+
+        // The US overnight session runs Sun 20:00 ET through Fri 04:00 ET, so it is the one
+        // stretch that exists outside the Monday–Friday rule below.
+        if market == .us {
+            if weekday == 1 { return m >= 20 * 60 ? .overnight : .closed } // Sunday evening opens the week
+            if (2...6).contains(weekday), m < 4 * 60 { return .overnight } // Mon–Fri small hours
+            if (2...5).contains(weekday), m >= 20 * 60 { return .overnight } // Mon–Thu nights (Friday night has no session)
+        }
+        guard (2...6).contains(weekday) else { return .closed }
 
         switch market {
         case .sh, .sz:
@@ -37,11 +49,13 @@ public enum TradingCalendar {
         }
     }
 
-    /// Whether this market is currently worth refreshing at high frequency
+    /// Whether this market is currently worth refreshing at high frequency.
+    /// Overnight counts as inactive here: most sources have nothing new then, and the ones
+    /// that do (Longbridge) declare it via `ProviderDescriptor.overnightMarkets`.
     public static func isActive(_ market: Market, at date: Date = .now) -> Bool {
         switch state(of: market, at: date) {
         case .regular, .preMarket, .postMarket: true
-        case .closed, .lunchBreak: false
+        case .closed, .lunchBreak, .overnight: false
         }
     }
 

--- a/Packages/PulseCore/Sources/PulseCore/Models/Quote.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Models/Quote.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public enum MarketState: String, Codable, Sendable {
     case preMarket, regular, postMarket, closed
+    /// US overnight session (Sun–Thu 20:00 → 04:00 ET); only some sources quote it
+    case overnight
 }
 
 /// A single quote snapshot. change/changePercent are derived from price and previousClose to avoid inconsistent definitions across data sources.

--- a/Packages/PulseCore/Sources/PulseCore/Providers/CompositeProvider.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Providers/CompositeProvider.swift
@@ -94,6 +94,10 @@ public actor CompositeProvider: QuoteProvider {
     }
 
     private func preferredQuoteProvider(for market: Market, among providers: [any QuoteProvider]) -> (any QuoteProvider)? {
+        // A user-keyed real-time source outranks the free delayed feeds whenever it is available.
+        if let longbridge = providers.first(where: { $0.descriptor.id == LongbridgeProvider.providerID }) {
+            return longbridge
+        }
         if market == .us, let yahoo = providers.first(where: { $0.descriptor.id == "yahoo" }) {
             return yahoo
         }
@@ -110,6 +114,21 @@ public actor CompositeProvider: QuoteProvider {
         } else {
             markUnhealthy(id, cooldown: cooldown)
         }
+    }
+
+    /// Preferred-provider grouping for a symbol set, before failover. The refresh engine
+    /// uses it to poll each group at its source's own cadence; symbols with no available
+    /// candidate are omitted.
+    public func quoteRouting(for symbols: [SymbolID]) -> [String: [SymbolID]] {
+        var groups: [String: [SymbolID]] = [:]
+        for symbol in symbols {
+            guard let primary = preferredQuoteProvider(
+                for: symbol.market,
+                among: candidates(.quotes, market: symbol.market)
+            ) else { continue }
+            groups[primary.descriptor.id, default: []].append(symbol)
+        }
+        return groups
     }
 
     /// Current health status of each data source (for debugging / the settings page)
@@ -210,6 +229,36 @@ public actor CompositeProvider: QuoteProvider {
         }
         candleCache[key] = CacheEntry(value: candles)
         return candles
+    }
+
+    /// Real-time push routes to the (sole) streaming-capable source. The stream resolves
+    /// availability internally so callers can treat "no stream" and "stream ends" the same.
+    public nonisolated func quoteStream(for symbols: [SymbolID]) -> AsyncThrowingStream<Quote, any Error>? {
+        guard let streamer = providers.first(where: { $0.descriptor.capabilities.contains(.streaming) }) else {
+            return nil
+        }
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                guard await !self.isDisabled(streamer.descriptor.id),
+                      let inner = streamer.quoteStream(for: symbols) else {
+                    continuation.finish()
+                    return
+                }
+                do {
+                    for try await quote in inner {
+                        continuation.yield(quote.sourced(by: streamer.descriptor))
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private func isDisabled(_ id: String) -> Bool {
+        disabledIDs.contains(id)
     }
 
     public func search(_ query: String) async throws -> [SymbolInfo] {

--- a/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgeHTTP.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgeHTTP.swift
@@ -1,0 +1,133 @@
+import Foundation
+import CryptoKit
+
+/// User-supplied Longbridge OpenAPI credentials (legacy API-key mode:
+/// App Key / App Secret / Access Token from the developer center).
+public struct LongbridgeCredentials: Codable, Sendable, Hashable {
+    public var appKey: String
+    public var appSecret: String
+    public var accessToken: String
+
+    public init(appKey: String, appSecret: String, accessToken: String) {
+        self.appKey = appKey
+        self.appSecret = appSecret
+        self.accessToken = accessToken
+    }
+
+    public var isComplete: Bool {
+        !appKey.isEmpty && !appSecret.isEmpty && !accessToken.isEmpty
+    }
+}
+
+/// Signed HTTP access to the Longbridge OpenAPI gateway. Pulse only needs it to
+/// exchange credentials for a socket OTP; quote data itself flows over the socket.
+struct LongbridgeHTTP: Sendable {
+    var host = URL(string: "https://openapi.longbridge.com")!
+    var credentials: LongbridgeCredentials
+    var session: URLSession
+
+    init(credentials: LongbridgeCredentials, session: URLSession? = nil) {
+        self.credentials = credentials
+        if let session {
+            self.session = session
+        } else {
+            let config = URLSessionConfiguration.ephemeral
+            config.timeoutIntervalForRequest = 10
+            self.session = URLSession(configuration: config)
+        }
+    }
+
+    /// GET /v1/socket/token — one-time password for authenticating the quote socket.
+    func fetchSocketOTP() async throws -> String {
+        let data = try await get(path: "/v1/socket/token")
+        struct Envelope: Decodable {
+            struct Payload: Decodable { var otp: String }
+            var code: Int
+            var message: String?
+            var data: Payload?
+        }
+        let envelope = try JSONDecoder().decode(Envelope.self, from: data)
+        guard envelope.code == 0, let otp = envelope.data?.otp else {
+            throw LongbridgeError.api(code: envelope.code, message: envelope.message ?? "unknown error")
+        }
+        return otp
+    }
+
+    private func get(path: String, query: String = "") async throws -> Data {
+        var components = URLComponents(url: host, resolvingAgainstBaseURL: false)!
+        components.path = path
+        if !query.isEmpty { components.percentEncodedQuery = query }
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = "GET"
+
+        let timestamp = String(Int(Date.now.timeIntervalSince1970))
+        request.setValue(credentials.appKey, forHTTPHeaderField: "X-Api-Key")
+        request.setValue(credentials.accessToken, forHTTPHeaderField: "Authorization")
+        request.setValue(timestamp, forHTTPHeaderField: "X-Timestamp")
+        request.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
+        request.setValue(Self.signature(
+            method: "GET", path: path, query: query,
+            credentials: credentials, timestamp: timestamp, body: nil
+        ), forHTTPHeaderField: "X-Api-Signature")
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw ProviderError.network(underlying: error.localizedDescription)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw ProviderError.badResponse("non-HTTP response")
+        }
+        switch http.statusCode {
+        case 200..<300: return data
+        case 429: throw ProviderError.rateLimited
+        case 400..<500: throw ProviderError.clientError(status: http.statusCode,
+                                                        detail: "HTTP \(http.statusCode) from Longbridge")
+        default: throw ProviderError.badResponse("HTTP \(http.statusCode) from Longbridge")
+        }
+    }
+
+    /// Request signature, byte-for-byte compatible with the official SDK implementation
+    /// (openapi/rust/crates/httpclient/src/signature.rs):
+    ///   canonical = "{method}|{path}|{query}|{signed header values}|{signed header names}|" + sha1hex(body)?
+    ///   signature = hex(hmacSHA256("HMAC-SHA256|" + sha1hex(canonical), appSecret))
+    static func signature(method: String, path: String, query: String,
+                          credentials: LongbridgeCredentials, timestamp: String, body: Data?) -> String {
+        let signedHeaders = "authorization;x-api-key;x-timestamp"
+        let signedValues = "authorization:\(credentials.accessToken)\nx-api-key:\(credentials.appKey)\nx-timestamp:\(timestamp)\n"
+
+        var canonical = "\(method)|\(path)|\(query)|\(signedValues)|\(signedHeaders)|"
+        if let body, !body.isEmpty {
+            canonical += sha1Hex(body)
+        }
+
+        let stringToSign = "HMAC-SHA256|" + sha1Hex(Data(canonical.utf8))
+        let mac = HMAC<SHA256>.authenticationCode(
+            for: Data(stringToSign.utf8),
+            using: SymmetricKey(data: Data(credentials.appSecret.utf8))
+        )
+        let hex = mac.map { String(format: "%02x", $0) }.joined()
+        return "HMAC-SHA256 SignedHeaders=\(signedHeaders), Signature=\(hex)"
+    }
+
+    private static func sha1Hex(_ data: Data) -> String {
+        Insecure.SHA1.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// How the Longbridge provider authenticates: user-pasted developer-center credentials, or
+/// OAuth tokens from the browser authorization flow.
+public enum LongbridgeAuth: Sendable {
+    case apiKey(LongbridgeCredentials)
+    case oauth(LongbridgeOAuthSession)
+}
+
+public enum LongbridgeError: Error, Sendable {
+    /// Business error from the OpenAPI gateway (non-zero code)
+    case api(code: Int, message: String)
+    /// Socket-level auth or transport failure
+    case socket(String)
+    /// Credentials missing — the provider is registered but not configured yet
+    case notConfigured
+}

--- a/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgeLoopbackServer.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgeLoopbackServer.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Network
+
+/// One-shot loopback HTTP endpoint for the OAuth redirect: binds 127.0.0.1, waits for the
+/// browser to hit the callback path, hands the URL to the flow, and answers with a small
+/// human-readable page so the tab never ends up blank. Everything else gets a 404.
+actor LongbridgeLoopbackServer {
+    enum LoopbackError: Error {
+        case portUnavailable(String)
+    }
+
+    private let port: UInt16
+    private let callbackPath: String
+    private let onCallback: @Sendable (URL) -> Void
+    private var listener: NWListener?
+    private var startContinuation: CheckedContinuation<Void, any Error>?
+
+    init(port: UInt16, callbackPath: String, onCallback: @escaping @Sendable (URL) -> Void) {
+        self.port = port
+        self.callbackPath = callbackPath
+        self.onCallback = onCallback
+    }
+
+    /// Binds the loopback port; throws when it is unavailable so the flow can fall back to
+    /// the custom-scheme redirect.
+    func start() async throws {
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = NWEndpoint.hostPort(
+            host: .ipv4(.loopback),
+            port: NWEndpoint.Port(rawValue: port)!
+        )
+        parameters.allowLocalEndpointReuse = true
+        let listener = try NWListener(using: parameters)
+        self.listener = listener
+
+        listener.newConnectionHandler = { [weak self] connection in
+            guard let self else { return }
+            Task { await self.handle(connection) }
+        }
+
+        listener.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            Task { await self.listenerStateChanged(state) }
+        }
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            startContinuation = continuation
+            listener.start(queue: .global(qos: .userInitiated))
+        }
+    }
+
+    private func listenerStateChanged(_ state: NWListener.State) {
+        switch state {
+        case .ready:
+            startContinuation?.resume()
+            startContinuation = nil
+        case .failed(let error), .waiting(let error):
+            listener?.cancel()
+            listener = nil
+            startContinuation?.resume(throwing: LoopbackError.portUnavailable(String(describing: error)))
+            startContinuation = nil
+        default:
+            break
+        }
+    }
+
+    func stop() {
+        listener?.cancel()
+        listener = nil
+    }
+
+    // MARK: - Connection handling
+
+    private func handle(_ connection: NWConnection) {
+        connection.start(queue: .global(qos: .userInitiated))
+        receiveRequest(connection, buffer: Data())
+    }
+
+    private func receiveRequest(_ connection: NWConnection, buffer: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 8192) { [weak self] data, _, isComplete, error in
+            guard let self, error == nil else {
+                connection.cancel()
+                return
+            }
+            var buffer = buffer
+            if let data { buffer.append(data) }
+            if buffer.range(of: Data("\r\n\r\n".utf8)) != nil || buffer.count > 16_384 {
+                Task { await self.respond(connection, request: buffer) }
+            } else if isComplete {
+                connection.cancel()
+            } else {
+                Task { await self.receiveRequest(connection, buffer: buffer) }
+            }
+        }
+    }
+
+    private func respond(_ connection: NWConnection, request: Data) {
+        // Request line: "GET /oauth/callback?code=…&state=… HTTP/1.1"
+        let head = String(decoding: request.prefix(2048), as: UTF8.self)
+        let target = Self.requestTarget(fromHead: head)
+
+        guard let target, target.hasPrefix(callbackPath),
+              let url = URL(string: "http://localhost:\(port)\(target)") else {
+            send(connection, response: Self.httpResponse(status: "404 Not Found", html: ""))
+            return
+        }
+
+        let denied = LongbridgeOAuthAuthenticator.queryValue("error", in: url) != nil
+        // The flow starts inside the app, so the page follows the app's language setting.
+        let chinese = PulseLocalization.currentLanguageIdentifier.hasPrefix("zh")
+        send(connection, response: Self.httpResponse(status: "200 OK", html: Self.resultPage(denied: denied, chinese: chinese)))
+        onCallback(url)
+    }
+
+    private func send(_ connection: NWConnection, response: Data) {
+        connection.send(content: response, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    // MARK: - HTTP bits
+
+    static func requestTarget(fromHead head: String) -> String? {
+        guard let requestLine = head.split(separator: "\r\n", maxSplits: 1).first else { return nil }
+        let parts = requestLine.split(separator: " ")
+        guard parts.count >= 2, parts[0] == "GET" else { return nil }
+        return String(parts[1])
+    }
+
+    static func httpResponse(status: String, html: String) -> Data {
+        let body = Data(html.utf8)
+        let head = "HTTP/1.1 \(status)\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: \(body.count)\r\nConnection: close\r\n\r\n"
+        return Data(head.utf8) + body
+    }
+
+    static func resultPage(denied: Bool, chinese: Bool) -> String {
+        let mark = denied ? "✕" : "✓"
+        let title: String
+        let body: String
+        if chinese {
+            title = denied ? "授权未完成" : "授权成功"
+            body = denied ? "你取消了授权,可以关闭此页面。" : "可以关闭此页面并返回 Pulse。"
+        } else {
+            title = denied ? "Authorization cancelled" : "Authorized"
+            body = denied ? "You cancelled the authorization — you can close this tab." : "You can close this tab and return to Pulse."
+        }
+        return """
+        <!doctype html><html lang="\(chinese ? "zh-Hans" : "en")"><head><meta charset="utf-8"><title>Pulse</title><style>
+        body { font-family: -apple-system, "PingFang SC", sans-serif; display: flex; min-height: 92vh;
+               align-items: center; justify-content: center; background: #ffffff; color: #1d1d1f; }
+        @media (prefers-color-scheme: dark) { body { background: #1c1c1e; color: #f5f5f7; } }
+        .card { text-align: center; }
+        .mark { font-size: 44px; line-height: 1; margin-bottom: 14px; color: \(denied ? "#ff9f0a" : "#30d158"); }
+        h2 { margin: 0 0 8px; font-size: 20px; font-weight: 600; }
+        p { margin: 0; font-size: 14px; color: #86868b; line-height: 1.7; }
+        </style></head><body><div class="card">
+        <div class="mark">\(mark)</div>
+        <h2>\(title)</h2>
+        <p>\(body)</p>
+        </div></body></html>
+        """
+    }
+}

--- a/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgeMessages.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgeMessages.swift
@@ -1,0 +1,321 @@
+import Foundation
+
+/// Command codes and message payloads for the Longbridge quote gateway.
+/// Definitions mirror longbridge/openapi-protobufs (quote/api.proto + control commands);
+/// only the subset Pulse needs is implemented.
+enum LongbridgeCommand: UInt8 {
+    case heartbeat = 1
+    case auth = 2
+    case reconnect = 3
+    case querySecurityQuote = 11
+    case queryIntraday = 18
+    case queryCandlestick = 19
+    case subscribe = 6
+    case unsubscribe = 7
+    case pushQuote = 101
+}
+
+enum LongbridgeMessages {
+    // MARK: - Control
+
+    /// message AuthRequest { string token = 1; map<string, string> metadata = 2; }
+    /// A protobuf map entry is a nested message: { 1: key, 2: value }.
+    static func authRequest(otp: String, metadata: [String: String] = [:]) -> Data {
+        var writer = ProtobufWriter()
+        writer.field(1, string: otp)
+        for (key, value) in metadata.sorted(by: { $0.key < $1.key }) {
+            var entry = ProtobufWriter()
+            entry.field(1, string: key)
+            entry.field(2, string: value)
+            writer.field(2, message: entry)
+        }
+        return writer.data
+    }
+
+    /// message AuthResponse { string session_id = 1; int64 expires = 2; }
+    struct AuthResponse {
+        var sessionID: String
+        var expires: Int64
+
+        init(decoding data: Data) throws {
+            var sessionID = ""
+            var expires: Int64 = 0
+            var reader = ProtobufReader(data)
+            while let field = try reader.nextField() {
+                switch field.number {
+                case 1: sessionID = field.value.string ?? ""
+                case 2: expires = field.value.int ?? 0
+                default: break
+                }
+            }
+            self.sessionID = sessionID
+            self.expires = expires
+        }
+    }
+
+    // MARK: - Quotes (cmd 11)
+
+    /// message MultiSecurityRequest { repeated string symbol = 1; }
+    static func multiSecurityRequest(symbols: [String]) -> Data {
+        var writer = ProtobufWriter()
+        for symbol in symbols {
+            writer.field(1, string: symbol)
+        }
+        return writer.data
+    }
+
+    /// message PrePostQuote { last_done=1; timestamp=2; volume=3; turnover=4; high=5; low=6; prev_close=7 }
+    struct PrePostQuote {
+        var lastDone: Double?
+        var timestamp: Int64 = 0
+        var volume: Int64 = 0
+        var turnover: Double?
+        var high: Double?
+        var low: Double?
+        var prevClose: Double?
+
+        init(decoding data: Data) throws {
+            var reader = ProtobufReader(data)
+            while let field = try reader.nextField() {
+                switch field.number {
+                case 1: lastDone = field.value.string.flatMap(Double.init)
+                case 2: timestamp = field.value.int ?? 0
+                case 3: volume = field.value.int ?? 0
+                case 4: turnover = field.value.string.flatMap(Double.init)
+                case 5: high = field.value.string.flatMap(Double.init)
+                case 6: low = field.value.string.flatMap(Double.init)
+                case 7: prevClose = field.value.string.flatMap(Double.init)
+                default: break
+                }
+            }
+        }
+    }
+
+    /// message SecurityQuote — see quote/api.proto
+    struct SecurityQuote {
+        var symbol = ""
+        var lastDone: Double?
+        var prevClose: Double?
+        var open: Double?
+        var high: Double?
+        var low: Double?
+        var timestamp: Int64 = 0
+        var volume: Int64 = 0
+        var turnover: Double?
+        var tradeStatus: Int64 = 0
+        var preMarket: PrePostQuote?
+        var postMarket: PrePostQuote?
+        var overnight: PrePostQuote?
+
+        init(decoding data: Data) throws {
+            var reader = ProtobufReader(data)
+            while let field = try reader.nextField() {
+                switch field.number {
+                case 1: symbol = field.value.string ?? ""
+                case 2: lastDone = field.value.string.flatMap(Double.init)
+                case 3: prevClose = field.value.string.flatMap(Double.init)
+                case 4: open = field.value.string.flatMap(Double.init)
+                case 5: high = field.value.string.flatMap(Double.init)
+                case 6: low = field.value.string.flatMap(Double.init)
+                case 7: timestamp = field.value.int ?? 0
+                case 8: volume = field.value.int ?? 0
+                case 9: turnover = field.value.string.flatMap(Double.init)
+                case 10: tradeStatus = field.value.int ?? 0
+                case 11: preMarket = try field.value.data.map { try PrePostQuote(decoding: $0) }
+                case 12: postMarket = try field.value.data.map { try PrePostQuote(decoding: $0) }
+                case 13: overnight = try field.value.data.map { try PrePostQuote(decoding: $0) }
+                default: break
+                }
+            }
+        }
+    }
+
+    /// message SecurityQuoteResponse { repeated SecurityQuote secu_quote = 1; }
+    static func decodeSecurityQuoteResponse(_ data: Data) throws -> [SecurityQuote] {
+        var quotes: [SecurityQuote] = []
+        var reader = ProtobufReader(data)
+        while let field = try reader.nextField() {
+            if field.number == 1, let payload = field.value.data {
+                quotes.append(try SecurityQuote(decoding: payload))
+            }
+        }
+        return quotes
+    }
+
+    // MARK: - Candlesticks (cmd 19)
+
+    /// enum Period — raw values shared with the wire format
+    enum Period: UInt64 {
+        case minute1 = 1
+        case minute5 = 5
+        case day = 1000
+        case week = 2000
+        case month = 3000
+
+        init?(_ period: CandlePeriod) {
+            switch period {
+            case .minute1: self = .minute1
+            case .minute5: self = .minute5
+            case .day: self = .day
+            case .week: self = .week
+            case .month: self = .month
+            }
+        }
+    }
+
+    /// message SecurityCandlestickRequest { symbol=1; period=2; count=3; adjust_type=4; trade_session=5 }
+    static func candlestickRequest(symbol: String, period: Period, count: Int) -> Data {
+        var writer = ProtobufWriter()
+        writer.field(1, string: symbol)
+        writer.field(2, varint: period.rawValue)
+        writer.field(3, varint: UInt64(count))
+        // adjust_type: NO_ADJUST(0), trade_session: NORMAL_TRADE(0) — proto3 zero fields are omitted
+        return writer.data
+    }
+
+    /// message Candlestick { close=1; open=2; low=3; high=4; volume=5; turnover=6; timestamp=7; trade_session=8 }
+    struct WireCandlestick {
+        var close: Double?
+        var open: Double?
+        var low: Double?
+        var high: Double?
+        var volume: Int64 = 0
+        var timestamp: Int64 = 0
+
+        init(decoding data: Data) throws {
+            var reader = ProtobufReader(data)
+            while let field = try reader.nextField() {
+                switch field.number {
+                case 1: close = field.value.string.flatMap(Double.init)
+                case 2: open = field.value.string.flatMap(Double.init)
+                case 3: low = field.value.string.flatMap(Double.init)
+                case 4: high = field.value.string.flatMap(Double.init)
+                case 5: volume = field.value.int ?? 0
+                case 7: timestamp = field.value.int ?? 0
+                default: break
+                }
+            }
+        }
+
+        var candle: Candle? {
+            guard let close, let open, let low, let high, timestamp > 0 else { return nil }
+            return Candle(
+                time: Date(timeIntervalSince1970: TimeInterval(timestamp)),
+                open: open, high: high, low: low, close: close,
+                volume: Double(volume)
+            )
+        }
+    }
+
+    /// message SecurityCandlestickResponse { symbol=1; repeated Candlestick candlesticks=2 }
+    static func decodeCandlestickResponse(_ data: Data) throws -> [Candle] {
+        var candles: [Candle] = []
+        var reader = ProtobufReader(data)
+        while let field = try reader.nextField() {
+            if field.number == 2, let payload = field.value.data,
+               let candle = try WireCandlestick(decoding: payload).candle {
+                candles.append(candle)
+            }
+        }
+        return candles
+    }
+
+    // MARK: - Subscription (cmd 6/7) and push (cmd 101)
+
+    /// message SubscribeRequest { repeated string symbol=1; repeated SubType sub_type=2; bool is_first_push=3 }
+    /// SubType.QUOTE = 1
+    static func subscribeQuoteRequest(symbols: [String]) -> Data {
+        var writer = ProtobufWriter()
+        for symbol in symbols {
+            writer.field(1, string: symbol)
+        }
+        writer.field(2, varint: 1) // QUOTE
+        writer.field(3, varint: 1) // is_first_push: deliver a snapshot immediately
+        return writer.data
+    }
+
+    /// message UnsubscribeRequest { repeated string symbol=1; repeated SubType sub_type=2; bool unsub_all=3 }
+    static func unsubscribeQuoteRequest(symbols: [String]) -> Data {
+        var writer = ProtobufWriter()
+        for symbol in symbols {
+            writer.field(1, string: symbol)
+        }
+        writer.field(2, varint: 1) // QUOTE
+        return writer.data
+    }
+
+    /// message PushQuote — see quote/api.proto (trade_session: 0 normal, 1 pre, 2 post, 3 overnight)
+    struct PushQuote {
+        var symbol = ""
+        var lastDone: Double?
+        var open: Double?
+        var high: Double?
+        var low: Double?
+        var timestamp: Int64 = 0
+        var volume: Int64 = 0
+        var turnover: Double?
+        var tradeSession: Int64 = 0
+
+        init(decoding data: Data) throws {
+            var reader = ProtobufReader(data)
+            while let field = try reader.nextField() {
+                switch field.number {
+                case 1: symbol = field.value.string ?? ""
+                case 3: lastDone = field.value.string.flatMap(Double.init)
+                case 4: open = field.value.string.flatMap(Double.init)
+                case 5: high = field.value.string.flatMap(Double.init)
+                case 6: low = field.value.string.flatMap(Double.init)
+                case 7: timestamp = field.value.int ?? 0
+                case 8: volume = field.value.int ?? 0
+                case 9: turnover = field.value.string.flatMap(Double.init)
+                case 11: tradeSession = field.value.int ?? 0
+                default: break
+                }
+            }
+        }
+
+        var marketState: MarketState {
+            switch tradeSession {
+            case 1: .preMarket
+            case 2: .postMarket
+            case 3: .overnight
+            default: .regular
+            }
+        }
+    }
+
+    // MARK: - Intraday (cmd 18)
+
+    /// message SecurityIntradayRequest { symbol=1; trade_session=2 }
+    static func intradayRequest(symbol: String) -> Data {
+        var writer = ProtobufWriter()
+        writer.field(1, string: symbol)
+        return writer.data
+    }
+
+    /// message Line { price=1; timestamp=2; volume=3; turnover=4; avg_price=5 }
+    /// message SecurityIntradayResponse { symbol=1; repeated Line lines=2 }
+    static func decodeIntradayResponse(_ data: Data) throws -> [(time: Date, price: Double, volume: Int64)] {
+        var lines: [(Date, Double, Int64)] = []
+        var reader = ProtobufReader(data)
+        while let field = try reader.nextField() {
+            guard field.number == 2, let payload = field.value.data else { continue }
+            var price: Double?
+            var timestamp: Int64 = 0
+            var volume: Int64 = 0
+            var lineReader = ProtobufReader(payload)
+            while let lineField = try lineReader.nextField() {
+                switch lineField.number {
+                case 1: price = lineField.value.string.flatMap(Double.init)
+                case 2: timestamp = lineField.value.int ?? 0
+                case 3: volume = lineField.value.int ?? 0
+                default: break
+                }
+            }
+            if let price, timestamp > 0 {
+                lines.append((Date(timeIntervalSince1970: TimeInterval(timestamp)), price, volume))
+            }
+        }
+        return lines
+    }
+}

--- a/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgeOAuth.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgeOAuth.swift
@@ -1,0 +1,336 @@
+import Foundation
+import CryptoKit
+
+/// OAuth 2.0 tokens for the Longbridge OpenAPI gateway. Refresh tokens rotate on every
+/// refresh, so whatever is persisted must be replaced immediately after each refresh —
+/// a stale refresh token is permanently dead.
+public struct LongbridgeOAuthTokens: Codable, Sendable, Hashable {
+    public var clientID: String
+    public var accessToken: String
+    public var refreshToken: String
+    public var expiresAt: Date
+
+    public init(clientID: String, accessToken: String, refreshToken: String, expiresAt: Date) {
+        self.clientID = clientID
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.expiresAt = expiresAt
+    }
+}
+
+/// Cached dynamic client registration (client id is not a secret; the redirect URIs are
+/// derived from the bundle id and loopback port, so dev and release builds register
+/// separate clients).
+struct LongbridgeOAuthClient: Codable, Sendable {
+    var clientID: String
+    var scope: String
+    var redirectURIs: [String]
+    var logoURI: String?
+}
+
+/// Browser-based authorization: dynamic client registration → authorize URL with PKCE →
+/// redirect back into the app → code/token exchange. The redirect prefers a one-shot
+/// loopback HTTP endpoint (proper success page in the tab, no "open app?" prompt) and
+/// falls back to the custom URL scheme when the port can't be bound; scheme callbacks are
+/// fed in via `handleCallback`.
+public actor LongbridgeOAuthAuthenticator {
+    public static let host = URL(string: "https://openapi.longbridge.com")!
+    static let loopbackPort: UInt16 = 41917
+    static let callbackPath = "/oauth/callback"
+    /// Shown by the authorize page next to the client name (RFC 7591 `logo_uri`).
+    static let logoURI = "https://pulse-market-glance.wangding0798.chatgpt.site/pulse-icon.png"
+    static var loopbackRedirectURI: String { "http://localhost:\(loopbackPort)\(callbackPath)" }
+    private static let clientCacheKey = "pulse.longbridge.oauthClient.v1"
+
+    private let schemeRedirectURI: String
+    private let clientName: String
+    private let defaults: UserDefaults
+    private var pending: PendingAuthorization?
+
+    private struct PendingAuthorization {
+        var state: String
+        var continuation: CheckedContinuation<URL, any Error>
+    }
+
+    public init(redirectScheme: String, clientName: String, defaults: UserDefaults = .standard) {
+        self.schemeRedirectURI = "\(redirectScheme)://oauth/callback"
+        self.clientName = clientName
+        self.defaults = defaults
+    }
+
+    // MARK: - Authorization flow
+
+    /// Runs the full browser authorization. `openURL` is called with the authorize page;
+    /// the flow completes when the browser redirects back, or fails after 5 minutes.
+    public func authorize(openURL: @Sendable @escaping (URL) -> Void) async throws -> LongbridgeOAuthTokens {
+        let client = try await ensureClient()
+
+        var server: LongbridgeLoopbackServer? = LongbridgeLoopbackServer(
+            port: Self.loopbackPort,
+            callbackPath: Self.callbackPath
+        ) { [weak self] url in
+            guard let self else { return }
+            Task { _ = await self.handleCallback(url) }
+        }
+        let redirectURI: String
+        do {
+            try await server?.start()
+            redirectURI = Self.loopbackRedirectURI
+        } catch {
+            server = nil
+            redirectURI = schemeRedirectURI
+        }
+
+        do {
+            let tokens = try await runAuthorization(client: client, redirectURI: redirectURI, openURL: openURL)
+            await server?.stop()
+            return tokens
+        } catch {
+            await server?.stop()
+            throw error
+        }
+    }
+
+    private func runAuthorization(client: LongbridgeOAuthClient, redirectURI: String,
+                                  openURL: @Sendable @escaping (URL) -> Void) async throws -> LongbridgeOAuthTokens {
+        let verifier = Self.randomURLSafe(32)
+        let state = Self.randomURLSafe(16)
+
+        var components = URLComponents(url: Self.host.appending(path: "/oauth2/authorize"), resolvingAgainstBaseURL: false)!
+        components.queryItems = [
+            .init(name: "response_type", value: "code"),
+            .init(name: "client_id", value: client.clientID),
+            .init(name: "redirect_uri", value: redirectURI),
+            .init(name: "scope", value: client.scope),
+            .init(name: "state", value: state),
+            .init(name: "code_challenge", value: Self.pkceChallenge(for: verifier)),
+            .init(name: "code_challenge_method", value: "S256"),
+        ]
+        let authorizeURL = components.url!
+
+        pending?.continuation.resume(throwing: CancellationError())
+        pending = nil
+
+        let timeout = Task {
+            try? await Task.sleep(for: .seconds(300))
+            self.expirePending(state: state)
+        }
+        defer { timeout.cancel() }
+
+        let callback: URL = try await withCheckedThrowingContinuation { continuation in
+            pending = PendingAuthorization(state: state, continuation: continuation)
+            openURL(authorizeURL)
+        }
+
+        guard let code = Self.queryValue("code", in: callback) else {
+            throw LongbridgeError.socket("authorization callback carried no code")
+        }
+        return try await Self.exchangeToken(clientID: client.clientID, form: [
+            "grant_type": "authorization_code",
+            "client_id": client.clientID,
+            "redirect_uri": redirectURI,
+            "code": code,
+            "code_verifier": verifier,
+        ])
+    }
+
+    /// Feed a `scheme://oauth/callback?...` URL from the system open-URL handler.
+    /// Returns whether the URL belonged to an in-flight authorization.
+    public func handleCallback(_ url: URL) -> Bool {
+        guard let pending, Self.queryValue("state", in: url) == pending.state else { return false }
+        self.pending = nil
+        pending.continuation.resume(returning: url)
+        return true
+    }
+
+    private func expirePending(state: String) {
+        guard let pending, pending.state == state else { return }
+        self.pending = nil
+        pending.continuation.resume(throwing: ProviderError.network(underlying: "authorization timed out"))
+    }
+
+    // MARK: - Dynamic client registration
+
+    private var desiredRedirectURIs: [String] {
+        [Self.loopbackRedirectURI, schemeRedirectURI]
+    }
+
+    private func ensureClient() async throws -> LongbridgeOAuthClient {
+        if let data = defaults.data(forKey: Self.clientCacheKey),
+           let cached = try? JSONDecoder().decode(LongbridgeOAuthClient.self, from: data),
+           Set(cached.redirectURIs) == Set(desiredRedirectURIs),
+           cached.logoURI == Self.logoURI {
+            return cached
+        }
+
+        var request = URLRequest(url: Self.host.appending(path: "/oauth2/register"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(Registration(
+            clientName: clientName,
+            redirectURIs: desiredRedirectURIs,
+            logoURI: Self.logoURI
+        ))
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard (response as? HTTPURLResponse)?.statusCode == 201 || (response as? HTTPURLResponse)?.statusCode == 200 else {
+            throw LongbridgeError.socket("OAuth client registration failed")
+        }
+        struct Registered: Decodable {
+            let clientID: String
+            let scope: String?
+            enum CodingKeys: String, CodingKey {
+                case clientID = "client_id"
+                case scope
+            }
+        }
+        let registered = try JSONDecoder().decode(Registered.self, from: data)
+        let client = LongbridgeOAuthClient(
+            clientID: registered.clientID,
+            scope: registered.scope ?? "",
+            redirectURIs: desiredRedirectURIs,
+            logoURI: Self.logoURI
+        )
+        defaults.set(try JSONEncoder().encode(client), forKey: Self.clientCacheKey)
+        return client
+    }
+
+    private struct Registration: Encodable {
+        var clientName: String
+        var redirectURIs: [String]
+        var logoURI: String
+        var grantTypes = ["authorization_code", "refresh_token"]
+        var responseTypes = ["code"]
+        var tokenEndpointAuthMethod = "none"
+
+        enum CodingKeys: String, CodingKey {
+            case clientName = "client_name"
+            case redirectURIs = "redirect_uris"
+            case logoURI = "logo_uri"
+            case grantTypes = "grant_types"
+            case responseTypes = "response_types"
+            case tokenEndpointAuthMethod = "token_endpoint_auth_method"
+        }
+    }
+
+    // MARK: - Token endpoint
+
+    static func exchangeToken(clientID: String, form: [String: String]) async throws -> LongbridgeOAuthTokens {
+        var request = URLRequest(url: host.appending(path: "/oauth2/token"))
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = form
+            .map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? $0.value)" }
+            .joined(separator: "&")
+            .data(using: .utf8)
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw ProviderError.network(underlying: error.localizedDescription)
+        }
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            let detail = String(data: data.prefix(200), encoding: .utf8) ?? ""
+            throw LongbridgeError.socket("token endpoint failed: \(detail)")
+        }
+        struct TokenResponse: Decodable {
+            let accessToken: String
+            let refreshToken: String?
+            let expiresIn: Double?
+            enum CodingKeys: String, CodingKey {
+                case accessToken = "access_token"
+                case refreshToken = "refresh_token"
+                case expiresIn = "expires_in"
+            }
+        }
+        let token = try JSONDecoder().decode(TokenResponse.self, from: data)
+        return LongbridgeOAuthTokens(
+            clientID: clientID,
+            accessToken: token.accessToken,
+            refreshToken: token.refreshToken ?? form["refresh_token"] ?? "",
+            expiresAt: Date.now.addingTimeInterval(token.expiresIn ?? 3600)
+        )
+    }
+
+    public static func refresh(_ tokens: LongbridgeOAuthTokens) async throws -> LongbridgeOAuthTokens {
+        try await exchangeToken(clientID: tokens.clientID, form: [
+            "grant_type": "refresh_token",
+            "client_id": tokens.clientID,
+            "refresh_token": tokens.refreshToken,
+        ])
+    }
+
+    // MARK: - PKCE helpers
+
+    static func pkceChallenge(for verifier: String) -> String {
+        base64URL(Data(SHA256.hash(data: Data(verifier.utf8))))
+    }
+
+    static func randomURLSafe(_ byteCount: Int) -> String {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        _ = SecRandomCopyBytes(kSecRandomDefault, byteCount, &bytes)
+        return base64URL(Data(bytes))
+    }
+
+    static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    static func queryValue(_ name: String, in url: URL) -> String? {
+        URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first { $0.name == name }?
+            .value
+    }
+}
+
+/// Owns live OAuth tokens for the quote connection: refreshes ahead of expiry and pushes
+/// every rotation to the persistence hook before use, then mints socket OTPs with the
+/// fresh bearer.
+public actor LongbridgeOAuthSession {
+    private var tokens: LongbridgeOAuthTokens
+    private let persist: @Sendable (LongbridgeOAuthTokens) -> Void
+
+    public init(tokens: LongbridgeOAuthTokens, persist: @escaping @Sendable (LongbridgeOAuthTokens) -> Void) {
+        self.tokens = tokens
+        self.persist = persist
+    }
+
+    public func fetchSocketOTP() async throws -> String {
+        let bearer = try await freshAccessToken()
+        var request = URLRequest(url: LongbridgeOAuthAuthenticator.host.appending(path: "/v1/socket/token"))
+        request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw ProviderError.network(underlying: error.localizedDescription)
+        }
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw ProviderError.badResponse("OTP request failed (HTTP \((response as? HTTPURLResponse)?.statusCode ?? -1))")
+        }
+        struct Envelope: Decodable {
+            struct Payload: Decodable { var otp: String }
+            var code: Int
+            var data: Payload?
+        }
+        let envelope = try JSONDecoder().decode(Envelope.self, from: data)
+        guard envelope.code == 0, let otp = envelope.data?.otp else {
+            throw LongbridgeError.api(code: envelope.code, message: "socket token rejected")
+        }
+        return otp
+    }
+
+    private func freshAccessToken() async throws -> String {
+        if tokens.expiresAt.timeIntervalSinceNow > 60 {
+            return tokens.accessToken
+        }
+        let refreshed = try await LongbridgeOAuthAuthenticator.refresh(tokens)
+        tokens = refreshed
+        persist(refreshed)
+        return refreshed.accessToken
+    }
+}

--- a/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgePacket.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgePacket.swift
@@ -1,0 +1,211 @@
+import Foundation
+import Compression
+
+/// Longbridge OpenAPI socket packet framing (BigEndian, "Longbridge Protocol" v1).
+/// Reference: https://open.longbridge.com/docs/socket/protocol/overview
+///
+/// Request  (type 1): [flags|type][cmd][request_id u32][timeout u16][body_len u24][body]
+/// Response (type 2): [flags|type][cmd][request_id u32][status u8][body_len u24][body]
+/// Push     (type 3): [flags|type][cmd][body_len u24][body]
+/// The first byte packs the packet type in its LOW nibble, verify in bit 4 and gzip in bit 5 —
+/// the docs' bit diagram reads MSB-first, but the reference implementation packs LSB-first
+/// (openapi-protocol/go/v1/header.go: `(type & 0xf) | (verify << 4) | (gzip << 5)`).
+enum LongbridgePacket {
+    enum Kind: UInt8 {
+        case request = 1
+        case response = 2
+        case push = 3
+    }
+
+    struct Response {
+        var command: UInt8
+        var requestID: UInt32
+        var status: UInt8
+        var body: Data
+    }
+
+    struct Push {
+        var command: UInt8
+        var body: Data
+    }
+
+    enum Inbound {
+        case response(Response)
+        case push(Push)
+        /// Heartbeat *requests* initiated by the server; the client must echo the body back.
+        case serverRequest(command: UInt8, requestID: UInt32, body: Data)
+    }
+
+    enum FramingError: Error {
+        case truncated
+        case unknownPacketType(UInt8)
+        case verifiedPacketUnsupported
+        case malformedGzipBody
+    }
+
+    // MARK: - Encoding
+
+    static func encodeRequest(command: UInt8, requestID: UInt32, body: Data, timeoutMS: UInt16 = 10_000) -> Data {
+        var data = Data(capacity: 11 + body.count)
+        data.append(Kind.request.rawValue)
+        data.append(command)
+        data.appendBigEndian(requestID)
+        data.appendBigEndian(timeoutMS)
+        data.appendUInt24(UInt32(body.count))
+        data.append(body)
+        return data
+    }
+
+    static func encodeResponse(command: UInt8, requestID: UInt32, status: UInt8, body: Data) -> Data {
+        var data = Data(capacity: 10 + body.count)
+        data.append(Kind.response.rawValue)
+        data.append(command)
+        data.appendBigEndian(requestID)
+        data.append(status)
+        data.appendUInt24(UInt32(body.count))
+        data.append(body)
+        return data
+    }
+
+    // MARK: - Decoding
+
+    /// Parses every packet contained in one WebSocket binary message.
+    static func decode(_ data: Data) throws -> [Inbound] {
+        var packets: [Inbound] = []
+        var cursor = LongbridgeByteCursor(data)
+        while !cursor.isAtEnd {
+            let head = try cursor.byte()
+            let kind = head & 0x0F
+            let verified = head >> 4 & 0x1 != 0
+            let gzipped = head >> 5 & 0x1 != 0
+            guard !verified else { throw FramingError.verifiedPacketUnsupported }
+
+            switch Kind(rawValue: kind) {
+            case .request:
+                let command = try cursor.byte()
+                let requestID = try cursor.uint32()
+                _ = try cursor.uint16() // timeout: irrelevant for server-initiated requests
+                let body = try body(&cursor, gzipped: gzipped)
+                packets.append(.serverRequest(command: command, requestID: requestID, body: body))
+            case .response:
+                let command = try cursor.byte()
+                let requestID = try cursor.uint32()
+                let status = try cursor.byte()
+                let body = try body(&cursor, gzipped: gzipped)
+                packets.append(.response(Response(command: command, requestID: requestID, status: status, body: body)))
+            case .push:
+                let command = try cursor.byte()
+                let body = try body(&cursor, gzipped: gzipped)
+                packets.append(.push(Push(command: command, body: body)))
+            case nil:
+                throw FramingError.unknownPacketType(kind)
+            }
+        }
+        return packets
+    }
+
+    private static func body(_ cursor: inout LongbridgeByteCursor, gzipped: Bool) throws -> Data {
+        let length = try cursor.uint24()
+        let raw = try cursor.bytes(Int(length))
+        return gzipped ? try gunzip(raw) : raw
+    }
+
+    // MARK: - Gzip
+
+    /// Bodies arrive gzip-wrapped when the gzip flag is set: RFC 1952 header + raw deflate + CRC32/ISIZE trailer.
+    static func gunzip(_ data: Data) throws -> Data {
+        guard data.count > 18, data[data.startIndex] == 0x1F, data[data.startIndex + 1] == 0x8B,
+              data[data.startIndex + 2] == 8 else {
+            throw FramingError.malformedGzipBody
+        }
+        let flags = data[data.startIndex + 3]
+        var offset = data.startIndex + 10
+        func advance(_ n: Int) throws {
+            guard data.distance(from: offset, to: data.endIndex) >= n else { throw FramingError.malformedGzipBody }
+            offset = data.index(offset, offsetBy: n)
+        }
+        if flags & 0x04 != 0 { // FEXTRA
+            try advance(2)
+            let xlen = Int(data[data.index(offset, offsetBy: -2)]) | Int(data[data.index(offset, offsetBy: -1)]) << 8
+            try advance(xlen)
+        }
+        for flag in [UInt8(0x08), 0x10] where flags & flag != 0 { // FNAME / FCOMMENT: null-terminated
+            while offset < data.endIndex, data[offset] != 0 { offset = data.index(after: offset) }
+            try advance(1)
+        }
+        if flags & 0x02 != 0 { try advance(2) } // FHCRC
+
+        guard data.distance(from: offset, to: data.endIndex) > 8 else { throw FramingError.malformedGzipBody }
+        let deflated = data.subdata(in: offset..<data.index(data.endIndex, offsetBy: -8))
+        // ISIZE trailer: uncompressed size mod 2^32, little-endian
+        let sizeBytes = data.suffix(4)
+        let expectedSize = sizeBytes.enumerated().reduce(0) { $0 | Int($1.element) << (8 * $1.offset) }
+        guard expectedSize > 0, expectedSize <= 16 * 1024 * 1024 else { throw FramingError.malformedGzipBody }
+
+        let destination = UnsafeMutablePointer<UInt8>.allocate(capacity: expectedSize)
+        defer { destination.deallocate() }
+        let written = deflated.withUnsafeBytes { source in
+            compression_decode_buffer(
+                destination, expectedSize,
+                source.bindMemory(to: UInt8.self).baseAddress!, deflated.count,
+                nil, COMPRESSION_ZLIB
+            )
+        }
+        guard written == expectedSize else { throw FramingError.malformedGzipBody }
+        return Data(bytes: destination, count: written)
+    }
+}
+
+/// Sequential BigEndian byte reader over a Data buffer.
+struct LongbridgeByteCursor {
+    private let data: Data
+    private var index: Data.Index
+
+    init(_ data: Data) {
+        self.data = data
+        self.index = data.startIndex
+    }
+
+    var isAtEnd: Bool { index == data.endIndex }
+
+    mutating func byte() throws -> UInt8 {
+        guard index < data.endIndex else { throw LongbridgePacket.FramingError.truncated }
+        defer { data.formIndex(after: &index) }
+        return data[index]
+    }
+
+    mutating func bytes(_ count: Int) throws -> Data {
+        guard count >= 0, data.distance(from: index, to: data.endIndex) >= count else {
+            throw LongbridgePacket.FramingError.truncated
+        }
+        let end = data.index(index, offsetBy: count)
+        defer { index = end }
+        return data.subdata(in: index..<end)
+    }
+
+    mutating func uint16() throws -> UInt16 {
+        try (0..<2).reduce(0) { acc, _ in try acc << 8 | UInt16(byte()) }
+    }
+
+    mutating func uint24() throws -> UInt32 {
+        try (0..<3).reduce(0) { acc, _ in try acc << 8 | UInt32(byte()) }
+    }
+
+    mutating func uint32() throws -> UInt32 {
+        try (0..<4).reduce(0) { acc, _ in try acc << 8 | UInt32(byte()) }
+    }
+}
+
+private extension Data {
+    mutating func appendBigEndian(_ value: UInt32) {
+        append(contentsOf: [UInt8(value >> 24 & 0xFF), UInt8(value >> 16 & 0xFF), UInt8(value >> 8 & 0xFF), UInt8(value & 0xFF)])
+    }
+
+    mutating func appendBigEndian(_ value: UInt16) {
+        append(contentsOf: [UInt8(value >> 8 & 0xFF), UInt8(value & 0xFF)])
+    }
+
+    mutating func appendUInt24(_ value: UInt32) {
+        append(contentsOf: [UInt8(value >> 16 & 0xFF), UInt8(value >> 8 & 0xFF), UInt8(value & 0xFF)])
+    }
+}

--- a/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgeProvider.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgeProvider.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+/// Longbridge OpenAPI quote source: real-time HK/US/CN quotes and candles over the
+/// Longbridge binary socket protocol, authenticated with user-supplied credentials
+/// (App Key / App Secret / Access Token from the developer center).
+///
+/// Pull-only for now; the same socket carries subscription push, which the future
+/// real-time mode will build on via `quoteStream`.
+public actor LongbridgeProvider: QuoteProvider {
+    public static let providerID = "longbridge"
+
+    private let socket = LongbridgeSocket()
+    private var configured = false
+
+    public init(auth: LongbridgeAuth? = nil) {
+        Task { await self.updateAuth(auth) }
+    }
+
+    /// Swaps the auth mode at runtime (settings page); drops the connection so the next
+    /// request authenticates freshly.
+    public func updateAuth(_ auth: LongbridgeAuth?) async {
+        switch auth {
+        case .apiKey(let credentials) where credentials.isComplete:
+            configured = true
+            await socket.updateOTPSource { try await LongbridgeHTTP(credentials: credentials).fetchSocketOTP() }
+        case .oauth(let session):
+            configured = true
+            await socket.updateOTPSource { try await session.fetchSocketOTP() }
+        default:
+            configured = false
+            await socket.updateOTPSource(nil)
+        }
+    }
+
+    public nonisolated var descriptor: ProviderDescriptor {
+        ProviderDescriptor(
+            id: Self.providerID,
+            name: PulseLocalization.localizedString("provider.longbridge"),
+            markets: [.us, .hk, .sh, .sz],
+            capabilities: [.quotes, .candles, .streaming],
+            delay: [.us: 0, .hk: 0, .sh: 0, .sz: 0],
+            rateLimit: RateLimitPolicy(minInterval: 0.12, batchSize: 500),
+            credentials: [
+                CredentialField(key: "appKey", label: "App Key", secure: false),
+                CredentialField(key: "appSecret", label: "App Secret"),
+                CredentialField(key: "accessToken", label: "Access Token"),
+            ],
+            // Push carries the liveliness; polling only reconciles and bootstraps
+            suggestedPollInterval: 60,
+            overnightMarkets: [.us]
+        )
+    }
+
+    /// Exercises the full credential path (signed OTP request + socket auth + one quote pull).
+    /// The settings page calls this when the user saves credentials.
+    public func validateConnection() async throws {
+        _ = try await quotes(for: [SymbolID(market: .hk, code: "700")])
+    }
+
+    // MARK: - QuoteProvider
+
+    public func search(_ query: String) async throws -> [SymbolInfo] {
+        throw ProviderError.unsupported(.search)
+    }
+
+    public func quotes(for symbols: [SymbolID]) async throws -> [Quote] {
+        guard configured else { throw LongbridgeError.notConfigured }
+        let mapped = symbols.compactMap { symbol in Self.longbridgeSymbol(for: symbol).map { (symbol, $0) } }
+        guard !mapped.isEmpty else { return [] }
+
+        let body = LongbridgeMessages.multiSecurityRequest(symbols: mapped.map(\.1))
+        let responseBody = try await socket.request(.querySecurityQuote, body: body)
+        let wireQuotes = try LongbridgeMessages.decodeSecurityQuoteResponse(responseBody)
+
+        let symbolByLongbridge = Dictionary(uniqueKeysWithValues: mapped.map { ($0.1, $0.0) })
+        return wireQuotes.compactMap { wire in
+            guard let symbol = symbolByLongbridge[wire.symbol] else { return nil }
+            return Self.quote(from: wire, symbol: symbol)
+        }
+    }
+
+    public func candles(for symbol: SymbolID, period: CandlePeriod, count: Int) async throws -> [Candle] {
+        guard configured else { throw LongbridgeError.notConfigured }
+        guard let lbSymbol = Self.longbridgeSymbol(for: symbol),
+              let lbPeriod = LongbridgeMessages.Period(period) else {
+            throw ProviderError.symbolNotFound(symbol)
+        }
+        let body = LongbridgeMessages.candlestickRequest(symbol: lbSymbol, period: lbPeriod, count: count)
+        let responseBody = try await socket.request(.queryCandlestick, body: body)
+        return try LongbridgeMessages.decodeCandlestickResponse(responseBody)
+    }
+
+    // MARK: - Real-time push (subscription over the same socket)
+
+    private struct StreamSubscriber {
+        var symbols: Set<String>
+        var continuation: AsyncThrowingStream<Quote, any Error>.Continuation
+    }
+
+    private var streamSubscribers: [UUID: StreamSubscriber] = [:]
+    /// Latest full quote per Longbridge symbol; pushes carry deltas (no prev_close), so
+    /// each push is merged over this base before being delivered.
+    private var streamBase: [String: Quote] = [:]
+
+    public nonisolated func quoteStream(for symbols: [SymbolID]) -> AsyncThrowingStream<Quote, any Error>? {
+        AsyncThrowingStream { continuation in
+            let id = UUID()
+            let task = Task {
+                await self.beginStream(id: id, symbols: symbols, continuation: continuation)
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+                Task { await self.endStream(id: id) }
+            }
+        }
+    }
+
+    private func beginStream(id: UUID, symbols: [SymbolID],
+                             continuation: AsyncThrowingStream<Quote, any Error>.Continuation) async {
+        guard configured else {
+            continuation.finish()
+            return
+        }
+        let mapped = symbols.compactMap { symbol in Self.longbridgeSymbol(for: symbol).map { ($0, symbol) } }
+        guard !mapped.isEmpty else {
+            continuation.finish()
+            return
+        }
+
+        await socket.setPushHandler { [weak self] command, body in
+            guard let self, command == LongbridgeCommand.pushQuote.rawValue else { return }
+            Task { await self.handleQuotePush(body) }
+        }
+
+        streamSubscribers[id] = StreamSubscriber(symbols: Set(mapped.map(\.0)), continuation: continuation)
+
+        do {
+            // Seed with full pull quotes: pushes lack prev_close, and the page wants a
+            // complete snapshot immediately rather than waiting for the first tick.
+            let seeded = try await quotes(for: symbols)
+            for quote in seeded {
+                if let lbSymbol = Self.longbridgeSymbol(for: quote.symbol) {
+                    streamBase[lbSymbol] = quote
+                }
+                continuation.yield(quote)
+            }
+            let body = LongbridgeMessages.subscribeQuoteRequest(symbols: mapped.map(\.0))
+            _ = try await socket.request(.subscribe, body: body)
+        } catch {
+            streamSubscribers[id] = nil
+            continuation.finish(throwing: error)
+        }
+    }
+
+    private func endStream(id: UUID) async {
+        guard let ended = streamSubscribers.removeValue(forKey: id) else { return }
+        let stillWanted = Set(streamSubscribers.values.flatMap(\.symbols))
+        let orphaned = ended.symbols.subtracting(stillWanted)
+        guard !orphaned.isEmpty else { return }
+        for symbol in orphaned {
+            streamBase[symbol] = nil
+        }
+        let body = LongbridgeMessages.unsubscribeQuoteRequest(symbols: Array(orphaned))
+        _ = try? await socket.request(.unsubscribe, body: body)
+    }
+
+    private func handleQuotePush(_ body: Data) {
+        guard let push = try? LongbridgeMessages.PushQuote(decoding: body),
+              var quote = streamBase[push.symbol] else { return }
+        if let price = push.lastDone { quote.price = price }
+        if let open = push.open { quote.open = open }
+        if let high = push.high { quote.high = high }
+        if let low = push.low { quote.low = low }
+        if push.volume > 0 { quote.volume = Double(push.volume) }
+        if let turnover = push.turnover { quote.turnover = turnover }
+        if push.timestamp > 0 { quote.timestamp = Date(timeIntervalSince1970: TimeInterval(push.timestamp)) }
+        quote.marketState = push.marketState
+        streamBase[push.symbol] = quote
+
+        for subscriber in streamSubscribers.values where subscriber.symbols.contains(push.symbol) {
+            subscriber.continuation.yield(quote)
+        }
+    }
+
+    // MARK: - Mapping
+
+    /// Pulse `SymbolID` → Longbridge `ticker.region`. Crypto is not covered by the
+    /// OpenAPI quote packages, so it stays with the other providers.
+    static func longbridgeSymbol(for symbol: SymbolID) -> String? {
+        switch symbol.market {
+        case .us: "\(symbol.code).US"
+        case .hk: "\(symbol.code).HK"
+        case .sh: "\(symbol.code).SH"
+        case .sz: "\(symbol.code).SZ"
+        case .crypto: nil
+        }
+    }
+
+    static func quote(from wire: LongbridgeMessages.SecurityQuote, symbol: SymbolID) -> Quote? {
+        guard let regularPrice = wire.lastDone, let prevClose = wire.prevClose else { return nil }
+
+        var price = regularPrice
+        var reference = prevClose
+        var state: MarketState = .regular
+        var timestamp = wire.timestamp
+
+        // US extended sessions: surface the live session price the way the Yahoo path does,
+        // with the change measured against that session's own reference close.
+        if symbol.market == .us {
+            let session: (quote: LongbridgeMessages.PrePostQuote?, state: MarketState)? =
+                switch TradingCalendar.state(of: .us) {
+                case .preMarket: (wire.preMarket, .preMarket)
+                case .postMarket: (wire.postMarket, .postMarket)
+                case .overnight: (wire.overnight, .overnight)
+                // Weekend/holiday: surface the freshest extended-session close if it beats
+                // the regular close (the timestamp guard below decides).
+                case .closed: (wire.overnight, .overnight)
+                default: nil
+                }
+            if let session, let sessionQuote = session.quote, let sessionPrice = sessionQuote.lastDone,
+               sessionQuote.timestamp >= wire.timestamp {
+                price = sessionPrice
+                reference = sessionQuote.prevClose ?? regularPrice
+                state = session.state
+                timestamp = sessionQuote.timestamp
+            }
+        }
+
+        return Quote(
+            symbol: symbol,
+            price: price,
+            previousClose: reference,
+            open: wire.open,
+            high: wire.high,
+            low: wire.low,
+            volume: Double(wire.volume),
+            turnover: wire.turnover,
+            currencyCode: symbol.market.currencyCode,
+            timestamp: timestamp > 0 ? Date(timeIntervalSince1970: TimeInterval(timestamp)) : .now,
+            marketState: state
+        )
+    }
+}

--- a/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgeSocket.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/LongbridgeSocket.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+/// One persistent connection to the Longbridge quote gateway (the account allows a single
+/// long link). Owns the WebSocket lifecycle: OTP auth, request/response pairing, heartbeats,
+/// and lazy reconnection on the next request after a drop.
+actor LongbridgeSocket {
+    static let endpoint = URL(string: "wss://openapi-quote.longbridge.com/v2?version=1&codec=1&platform=9")!
+
+    /// Produces a one-time socket password. The concrete auth mode (signed API-key HTTP or
+    /// an OAuth bearer) lives entirely behind this closure.
+    typealias OTPSource = @Sendable () async throws -> String
+
+    private var otpSource: OTPSource?
+    private var onPush: (@Sendable (UInt8, Data) -> Void)?
+    private var task: URLSessionWebSocketTask?
+    private var receiveLoop: Task<Void, Never>?
+    private var heartbeatLoop: Task<Void, Never>?
+    private var nextRequestID: UInt32 = 1
+    private var pending: [UInt32: CheckedContinuation<LongbridgePacket.Response, any Error>] = [:]
+    private let session: URLSession
+    private let requestTimeout: Duration = .seconds(10)
+
+    init(session: URLSession = URLSession(configuration: .ephemeral)) {
+        self.session = session
+    }
+
+    func updateOTPSource(_ source: OTPSource?) {
+        otpSource = source
+        disconnect(reason: "auth changed")
+    }
+
+    /// Receives business push packets (quote subscriptions). Control pushes stay internal.
+    func setPushHandler(_ handler: (@Sendable (UInt8, Data) -> Void)?) {
+        onPush = handler
+    }
+
+    // MARK: - Requests
+
+    func request(_ command: LongbridgeCommand, body: Data) async throws -> Data {
+        try await ensureConnected()
+        let response = try await send(command: command, body: body)
+        return try Self.unwrap(response)
+    }
+
+    private static func unwrap(_ response: LongbridgePacket.Response) throws -> Data {
+        switch response.status {
+        case 0: return response.body
+        case 5: throw ProviderError.badResponse("Longbridge socket unauthenticated")
+        case 1: throw ProviderError.badResponse("Longbridge request timed out on server")
+        default: throw ProviderError.badResponse("Longbridge socket status \(response.status)")
+        }
+    }
+
+    /// Sends one framed request and waits for the paired response, bounded by `requestTimeout`
+    /// so a dropped connection can never leave a caller suspended forever.
+    /// The continuation is registered before the frame goes out — the response can otherwise
+    /// arrive on the receive loop before registration and be dropped.
+    private func send(command: LongbridgeCommand, body: Data) async throws -> LongbridgePacket.Response {
+        guard let task else { throw LongbridgeError.socket("not connected") }
+        let requestID = nextRequestID
+        nextRequestID = nextRequestID == .max ? 1 : nextRequestID + 1
+        let frame = LongbridgePacket.encodeRequest(command: command.rawValue, requestID: requestID, body: body)
+
+        let timeout = Task { [requestTimeout] in
+            try? await Task.sleep(for: requestTimeout)
+            self.fail(requestID, with: ProviderError.network(underlying: "Longbridge request timed out"))
+        }
+        defer { timeout.cancel() }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            pending[requestID] = continuation
+            Task {
+                do {
+                    try await task.send(.data(frame))
+                } catch {
+                    self.fail(requestID, with: ProviderError.network(underlying: error.localizedDescription))
+                    self.connectionLost()
+                }
+            }
+        }
+    }
+
+    private func fail(_ requestID: UInt32, with error: any Error) {
+        pending.removeValue(forKey: requestID)?.resume(throwing: error)
+    }
+
+    // MARK: - Connection lifecycle
+
+    private func ensureConnected() async throws {
+        if task != nil { return }
+        guard let otpSource else { throw LongbridgeError.notConfigured }
+
+        // OTP is single-use; the socket authenticates with it right after connecting.
+        let otp = try await otpSource()
+
+        let socketTask = session.webSocketTask(with: Self.endpoint)
+        socketTask.resume()
+        task = socketTask
+        startReceiveLoop(socketTask)
+
+        do {
+            // Overnight quotes are opt-in per connection; without this metadata the server
+            // omits over_night_quote from pulls and never pushes overnight ticks.
+            let body = LongbridgeMessages.authRequest(otp: otp, metadata: ["need_over_night_quote": "true"])
+            let response = try await send(command: .auth, body: body)
+            guard response.status == 0 else {
+                throw LongbridgeError.socket("auth rejected with status \(response.status)")
+            }
+            _ = try LongbridgeMessages.AuthResponse(decoding: response.body)
+        } catch {
+            disconnect(reason: "auth failed")
+            throw error
+        }
+        startHeartbeat()
+    }
+
+    private func startReceiveLoop(_ socketTask: URLSessionWebSocketTask) {
+        receiveLoop = Task {
+            while !Task.isCancelled {
+                do {
+                    let message = try await socketTask.receive()
+                    guard case .data(let data) = message else { continue }
+                    for packet in try LongbridgePacket.decode(data) {
+                        self.handle(packet, on: socketTask)
+                    }
+                } catch {
+                    self.connectionLost()
+                    return
+                }
+            }
+        }
+    }
+
+    private func handle(_ packet: LongbridgePacket.Inbound, on socketTask: URLSessionWebSocketTask) {
+        switch packet {
+        case .response(let response):
+            pending.removeValue(forKey: response.requestID)?.resume(returning: response)
+        case .serverRequest(let command, let requestID, let body):
+            // Heartbeat contract: echo the body back with the same request id.
+            if command == LongbridgeCommand.heartbeat.rawValue {
+                let reply = LongbridgePacket.encodeResponse(command: command, requestID: requestID, status: 0, body: body)
+                Task { try? await socketTask.send(.data(reply)) }
+            }
+        case .push(let push):
+            // cmd 0 is the server's close notice; everything else is subscription data.
+            if push.command == 0 {
+                connectionLost()
+            } else {
+                onPush?(push.command, push.body)
+            }
+        }
+    }
+
+    private func startHeartbeat() {
+        heartbeatLoop = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(30))
+                guard !Task.isCancelled else { return }
+                var writer = ProtobufWriter()
+                writer.field(1, int: Int64(Date.now.timeIntervalSince1970))
+                _ = try? await self.request(.heartbeat, body: writer.data)
+            }
+        }
+    }
+
+    private func connectionLost() {
+        disconnect(reason: "connection lost")
+    }
+
+    private func disconnect(reason: String) {
+        receiveLoop?.cancel()
+        receiveLoop = nil
+        heartbeatLoop?.cancel()
+        heartbeatLoop = nil
+        task?.cancel(with: .goingAway, reason: nil)
+        task = nil
+        let waiting = pending
+        pending.removeAll()
+        for continuation in waiting.values {
+            continuation.resume(throwing: ProviderError.network(underlying: "Longbridge socket closed: \(reason)"))
+        }
+    }
+}

--- a/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/ProtobufCodec.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Providers/Longbridge/ProtobufCodec.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Minimal protobuf (proto3) wire-format codec covering exactly what the Longbridge quote
+/// protocol needs: varint (wire type 0) and length-delimited (wire type 2) fields.
+/// Hand-rolled to keep PulseCore dependency-free; the message set is small and stable.
+enum ProtobufWireType: UInt8 {
+    case varint = 0
+    case fixed64 = 1
+    case lengthDelimited = 2
+    case fixed32 = 5
+}
+
+struct ProtobufWriter {
+    private(set) var data = Data()
+
+    mutating func appendVarint(_ value: UInt64) {
+        var v = value
+        while v >= 0x80 {
+            data.append(UInt8((v & 0x7F) | 0x80))
+            v >>= 7
+        }
+        data.append(UInt8(v))
+    }
+
+    private mutating func appendTag(field: Int, type: ProtobufWireType) {
+        appendVarint(UInt64(field) << 3 | UInt64(type.rawValue))
+    }
+
+    /// proto3 omits zero-valued scalar fields
+    mutating func field(_ number: Int, varint value: UInt64) {
+        guard value != 0 else { return }
+        appendTag(field: number, type: .varint)
+        appendVarint(value)
+    }
+
+    mutating func field(_ number: Int, int value: Int64) {
+        field(number, varint: UInt64(bitPattern: value))
+    }
+
+    mutating func field(_ number: Int, string value: String) {
+        guard !value.isEmpty else { return }
+        field(number, bytes: Data(value.utf8))
+    }
+
+    mutating func field(_ number: Int, bytes value: Data) {
+        appendTag(field: number, type: .lengthDelimited)
+        appendVarint(UInt64(value.count))
+        data.append(value)
+    }
+
+    mutating func field(_ number: Int, message: ProtobufWriter) {
+        field(number, bytes: message.data)
+    }
+}
+
+enum ProtobufDecodingError: Error {
+    case truncated
+    case malformedVarint
+    case unsupportedWireType(UInt8)
+}
+
+/// Streaming field reader. Iterate with `nextField()` and switch on the field number;
+/// unknown fields are skipped by the caller via the returned value, matching proto3 semantics.
+struct ProtobufReader {
+    enum Value {
+        case varint(UInt64)
+        case bytes(Data)
+
+        var uint: UInt64? {
+            if case .varint(let v) = self { return v }
+            return nil
+        }
+
+        var int: Int64? { uint.map { Int64(bitPattern: $0) } }
+
+        var data: Data? {
+            if case .bytes(let d) = self { return d }
+            return nil
+        }
+
+        var string: String? { data.flatMap { String(data: $0, encoding: .utf8) } }
+    }
+
+    private let data: Data
+    private var index: Data.Index
+
+    init(_ data: Data) {
+        self.data = data
+        self.index = data.startIndex
+    }
+
+    var isAtEnd: Bool { index == data.endIndex }
+
+    private mutating func readVarint() throws -> UInt64 {
+        var result: UInt64 = 0
+        var shift: UInt64 = 0
+        while true {
+            guard index < data.endIndex else { throw ProtobufDecodingError.truncated }
+            guard shift < 64 else { throw ProtobufDecodingError.malformedVarint }
+            let byte = data[index]
+            data.formIndex(after: &index)
+            result |= UInt64(byte & 0x7F) << shift
+            if byte & 0x80 == 0 { return result }
+            shift += 7
+        }
+    }
+
+    private mutating func readBytes(_ count: Int) throws -> Data {
+        guard count >= 0, data.distance(from: index, to: data.endIndex) >= count else {
+            throw ProtobufDecodingError.truncated
+        }
+        let end = data.index(index, offsetBy: count)
+        defer { index = end }
+        return data.subdata(in: index..<end)
+    }
+
+    mutating func nextField() throws -> (number: Int, value: Value)? {
+        guard !isAtEnd else { return nil }
+        let tag = try readVarint()
+        let number = Int(tag >> 3)
+        let rawType = UInt8(tag & 0x7)
+        switch ProtobufWireType(rawValue: rawType) {
+        case .varint:
+            return (number, .varint(try readVarint()))
+        case .lengthDelimited:
+            let length = Int(try readVarint())
+            return (number, .bytes(try readBytes(length)))
+        case .fixed64:
+            _ = try readBytes(8)
+            return try nextField()
+        case .fixed32:
+            _ = try readBytes(4)
+            return try nextField()
+        case nil:
+            throw ProtobufDecodingError.unsupportedWireType(rawType)
+        }
+    }
+}

--- a/Packages/PulseCore/Sources/PulseCore/Providers/ProviderDescriptor.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Providers/ProviderDescriptor.swift
@@ -47,11 +47,18 @@ public struct ProviderDescriptor: Codable, Sendable, Hashable {
     public var delay: [Market: TimeInterval]
     public var rateLimit: RateLimitPolicy?
     public var credentials: [CredentialField]
+    /// Default quote-poll cadence for this source (seconds). The user can override it per
+    /// provider; sources with push streaming only need polling as reconciliation.
+    public var suggestedPollInterval: TimeInterval?
+    /// Markets this source keeps quoting during the overnight session (currently a US
+    /// concept). Other sources are simply not polled overnight.
+    public var overnightMarkets: Set<Market>
 
     public init(id: String, name: String, markets: Set<Market>, capabilities: Set<Capability>,
                 candleMarkets: Set<Market>? = nil, candlePeriods: Set<CandlePeriod>? = nil,
                 delay: [Market: TimeInterval] = [:], rateLimit: RateLimitPolicy? = nil,
-                credentials: [CredentialField] = []) {
+                credentials: [CredentialField] = [], suggestedPollInterval: TimeInterval? = nil,
+                overnightMarkets: Set<Market> = []) {
         self.id = id
         self.name = name
         self.markets = markets
@@ -61,6 +68,25 @@ public struct ProviderDescriptor: Codable, Sendable, Hashable {
         self.delay = delay
         self.rateLimit = rateLimit
         self.credentials = credentials
+        self.suggestedPollInterval = suggestedPollInterval
+        self.overnightMarkets = overnightMarkets
+    }
+
+    /// How fresh this source's data is across its markets, for display.
+    public enum DelayClass {
+        /// Every covered market is zero-delay
+        case realtime
+        /// Some markets are zero-delay, others delayed
+        case partiallyRealtime
+        /// No market is zero-delay
+        case delayed
+    }
+
+    public var delayClass: DelayClass {
+        let delays = markets.map { delay[$0] ?? 0 }
+        if delays.allSatisfy({ $0 == 0 }) { return .realtime }
+        if delays.contains(0) { return .partiallyRealtime }
+        return .delayed
     }
 
     public func supports(_ capability: Capability, in market: Market) -> Bool {

--- a/Packages/PulseCore/Sources/PulseCore/Providers/TencentProvider.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Providers/TencentProvider.swift
@@ -19,7 +19,8 @@ public struct TencentProvider: QuoteProvider {
             candleMarkets: [.sh, .sz],
             candlePeriods: [.minute1, .minute5],
             delay: [.us: 0, .hk: 900, .sh: 0, .sz: 0],
-            rateLimit: RateLimitPolicy(minInterval: 2, batchSize: 60)
+            rateLimit: RateLimitPolicy(minInterval: 2, batchSize: 60),
+            suggestedPollInterval: 15
         )
     }
 

--- a/Packages/PulseCore/Sources/PulseCore/Providers/YahooProvider.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Providers/YahooProvider.swift
@@ -16,7 +16,9 @@ public struct YahooProvider: QuoteProvider {
             markets: [.us, .hk, .sh, .sz, .crypto],
             capabilities: [.search, .quotes, .candles],
             delay: [.us: 0, .hk: 900, .sh: 900, .sz: 900, .crypto: 0],
-            rateLimit: RateLimitPolicy(minInterval: 1, batchSize: 1)
+            rateLimit: RateLimitPolicy(minInterval: 1, batchSize: 1),
+            // Yahoo rate-limits aggressively per IP; poll politely and let pushes/others carry liveliness
+            suggestedPollInterval: 60
         )
     }
 
@@ -268,7 +270,7 @@ public struct YahooProvider: QuoteProvider {
         chartPreviousClose: Double?
     ) -> Double {
         switch state {
-        case .preMarket, .postMarket:
+        case .preMarket, .postMarket, .overnight:
             return regularPrice
         case .regular, .closed:
             return previousClose ?? chartPreviousClose ?? regularPrice

--- a/Packages/PulseCore/Sources/PulseCore/Store/MarketStore.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Store/MarketStore.swift
@@ -55,8 +55,11 @@ public final class MarketStore {
 
     /// Polls and pushes race: a poll served from a provider-side cache can arrive after a
     /// fresher push. Never let an older market timestamp overwrite a newer one.
+    /// Timestamps are only comparable within one source, though — when the serving source
+    /// changes (user toggled a provider, or routing failed over), the replacement carries
+    /// the freshest data its source has, even if its market timestamp is older.
     private func isFresher(_ incoming: Quote, than existing: Quote?) -> Bool {
-        guard let existing else { return true }
+        guard let existing, incoming.sourceID == existing.sourceID else { return true }
         return incoming.timestamp >= existing.timestamp
     }
 

--- a/Packages/PulseCore/Sources/PulseCore/Store/MarketStore.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Store/MarketStore.swift
@@ -31,12 +31,33 @@ public final class MarketStore {
         // Merge into a copy first, then assign once: a batch of quotes triggers only one view invalidation.
         // Writing entries one by one would re-render the list N times per tick (one of the culprits behind popover jank)
         var merged = quotes
-        for quote in newQuotes {
+        for quote in newQuotes where isFresher(quote, than: merged[quote.symbol]) {
             merged[quote.symbol] = quote
         }
         quotes = merged
         lastRefresh = .now
         lastError = nil
+    }
+
+    /// Merges push-delivered quotes (already coalesced upstream). Unlike a poll round it
+    /// leaves `lastRefresh` and `lastError` alone — pushes are ticks, not health signals.
+    public func applyStreamed(_ newQuotes: [Quote]) {
+        var merged = quotes
+        var changed = false
+        for quote in newQuotes where isFresher(quote, than: merged[quote.symbol]) {
+            merged[quote.symbol] = quote
+            changed = true
+        }
+        if changed {
+            quotes = merged
+        }
+    }
+
+    /// Polls and pushes race: a poll served from a provider-side cache can arrive after a
+    /// fresher push. Never let an older market timestamp overwrite a newer one.
+    private func isFresher(_ incoming: Quote, than existing: Quote?) -> Bool {
+        guard let existing else { return true }
+        return incoming.timestamp >= existing.timestamp
     }
 
     public func apply(sparkline values: [Double], for symbol: SymbolID) {

--- a/Packages/PulseCore/Sources/PulseCore/Store/RefreshEngine.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Store/RefreshEngine.swift
@@ -2,15 +2,13 @@ import Foundation
 import Observation
 
 /// Refresh scheduling: a trading-session-aware polling loop.
-/// Providers handle HOW to fetch data; this handles WHEN — throttling, slowing down when idle, and low-frequency sparkline refreshes alongside quotes.
+/// Providers handle HOW to fetch data; this handles WHEN. Each data source polls at its own
+/// cadence (user override → descriptor suggestion → 15s default): the scheduler ticks on a
+/// short base interval, groups the watchlist by preferred provider, and polls exactly the
+/// groups whose cadence has elapsed. Sparklines refresh on their own low-frequency track.
 @MainActor
 @Observable
 public final class RefreshEngine {
-    /// Refresh interval while markets are open (seconds), user-configurable
-    public var activeInterval: TimeInterval {
-        didSet { poke() }
-    }
-
     /// Polling interval when all markets are closed (waiting for the open / next day)
     public var idleInterval: TimeInterval = 300
 
@@ -24,13 +22,35 @@ public final class RefreshEngine {
     @ObservationIgnored private let watchlist: WatchlistStore
     @ObservationIgnored private var loopTask: Task<Void, Never>?
     @ObservationIgnored private var lastSparklineAt: [SymbolID: Date] = [:]
+    @ObservationIgnored private var lastPollAt: [String: Date] = [:]
+    @ObservationIgnored private var pollOverrides: [String: TimeInterval]
+    @ObservationIgnored private lazy var suggestedIntervals: [String: TimeInterval] = {
+        Dictionary(uniqueKeysWithValues: provider.registeredDescriptors.compactMap { descriptor in
+            descriptor.suggestedPollInterval.map { (descriptor.id, $0) }
+        })
+    }()
+
+    private static let fallbackPollInterval: TimeInterval = 15
+    /// Scheduler resolution while any covered market trades; also the fastest selectable cadence
+    private static let baseTick: TimeInterval = 5
 
     public init(provider: CompositeProvider, store: MarketStore, watchlist: WatchlistStore,
-                activeInterval: TimeInterval = 15) {
+                pollOverrides: [String: TimeInterval] = [:]) {
         self.provider = provider
         self.store = store
         self.watchlist = watchlist
-        self.activeInterval = activeInterval
+        self.pollOverrides = pollOverrides
+    }
+
+    /// Effective quote cadence for one source: user override → descriptor suggestion → default.
+    public func pollInterval(for providerID: String) -> TimeInterval {
+        pollOverrides[providerID] ?? suggestedIntervals[providerID] ?? Self.fallbackPollInterval
+    }
+
+    public func setPollOverride(_ interval: TimeInterval?, for providerID: String) {
+        pollOverrides[providerID] = interval
+        lastPollAt[providerID] = nil // apply the new cadence right away
+        poke()
     }
 
     public func start() {
@@ -40,7 +60,10 @@ public final class RefreshEngine {
             while !Task.isCancelled {
                 guard let self else { return }
                 await self.tick()
-                let interval = self.currentInterval()
+                let markets = Set(self.watchlist.symbols.map(\.market))
+                // Wake at scheduler resolution while trading; slow down off-hours (the
+                // per-symbol worth-refreshing filter keeps off-hour ticks request-free).
+                let interval = TradingCalendar.anyActive(markets) ? Self.baseTick : 60
                 try? await Task.sleep(for: .seconds(interval))
             }
         }
@@ -57,25 +80,26 @@ public final class RefreshEngine {
         guard loopTask != nil else { return }
         loopTask?.cancel()
         loopTask = nil
+        lastPollAt = [:] // a poke means "refresh everything now", regardless of cadence
         start()
-    }
-
-    private func currentInterval() -> TimeInterval {
-        let markets = Set(watchlist.symbols.map(\.market))
-        if TradingCalendar.anyActive(markets) { return activeInterval }
-        // Post-close settlement window: free sources are delayed ~15 minutes intraday, so quotes take a while after the close to converge on the official closing price.
-        // Keep a medium refresh rate for 35 minutes after the close so closing prices align quickly, instead of dropping straight to the 5-minute idle poll.
-        let wasActiveRecently = TradingCalendar.anyActive(markets, at: .now.addingTimeInterval(-35 * 60))
-        return wasActiveRecently ? 60 : idleInterval
     }
 
     private func tick() async {
         let symbols = watchlist.symbols
         guard !symbols.isEmpty else { return }
 
-        let quoteSymbols = symbolsWorthRefreshing(symbols)
-        do {
-            if !quoteSymbols.isEmpty {
+        let routing = await provider.quoteRouting(for: symbols)
+        let overnightByProvider = Dictionary(uniqueKeysWithValues: provider.registeredDescriptors.map {
+            ($0.id, $0.overnightMarkets)
+        })
+        for (providerID, group) in routing {
+            let last = lastPollAt[providerID] ?? .distantPast
+            guard Date.now.timeIntervalSince(last) >= pollInterval(for: providerID) else { continue }
+
+            let quoteSymbols = symbolsWorthRefreshing(group, overnightMarkets: overnightByProvider[providerID] ?? [])
+            guard !quoteSymbols.isEmpty else { continue }
+            lastPollAt[providerID] = .now
+            do {
                 let quotes = try await provider.quotes(for: quoteSymbols)
                 store.apply(quotes: quotes)
                 // Write the latest name from quotes back to the watchlist (the search-result name captured at add time can be rough)
@@ -84,19 +108,22 @@ public final class RefreshEngine {
                         watchlist.updateDisplayName(quote.symbol, name: name)
                     }
                 }
+            } catch {
+                store.reportError(String(describing: error))
             }
-        } catch {
-            store.reportError(String(describing: error))
         }
 
         await refreshSparklinesIfDue(symbols: symbols)
     }
 
-    private func symbolsWorthRefreshing(_ symbols: [SymbolID]) -> [SymbolID] {
+    private func symbolsWorthRefreshing(_ symbols: [SymbolID], overnightMarkets: Set<Market>) -> [SymbolID] {
         let now = Date.now
         return symbols.filter { symbol in
             if store.quote(for: symbol) == nil { return true }
             if TradingCalendar.isActive(symbol.market, at: now) { return true }
+            // Overnight polls only against sources that actually quote the session
+            if overnightMarkets.contains(symbol.market),
+               TradingCalendar.state(of: symbol.market, at: now) == .overnight { return true }
             return TradingCalendar.isActive(symbol.market, at: now.addingTimeInterval(-35 * 60))
         }
     }

--- a/Packages/PulseCore/Sources/PulseCore/Support/LongbridgeCredentialStore.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Support/LongbridgeCredentialStore.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Security
+
+/// Keychain persistence for the user's Longbridge OpenAPI secrets — legacy API-key
+/// credentials and OAuth tokens live under separate accounts. Both can trade the user's
+/// account, so neither ever touches UserDefaults.
+public enum LongbridgeCredentialStore {
+    private static let service = "app.pulse.longbridge"
+    private static let apiKeyAccount = "openapi-credentials"
+    private static let oauthAccount = "oauth-tokens"
+
+    // MARK: - Legacy API-key credentials
+
+    public static func load() -> LongbridgeCredentials? {
+        loadValue(account: apiKeyAccount)
+    }
+
+    public static func save(_ credentials: LongbridgeCredentials) throws {
+        try saveValue(credentials, account: apiKeyAccount)
+    }
+
+    public static func clear() {
+        SecItemDelete(baseQuery(account: apiKeyAccount) as CFDictionary)
+    }
+
+    // MARK: - OAuth tokens
+
+    public static func loadOAuthTokens() -> LongbridgeOAuthTokens? {
+        loadValue(account: oauthAccount)
+    }
+
+    public static func saveOAuthTokens(_ tokens: LongbridgeOAuthTokens) throws {
+        try saveValue(tokens, account: oauthAccount)
+    }
+
+    public static func clearOAuthTokens() {
+        SecItemDelete(baseQuery(account: oauthAccount) as CFDictionary)
+    }
+
+    // MARK: - Keychain plumbing
+
+    private static func loadValue<Value: Decodable>(account: String) -> Value? {
+        var query = baseQuery(account: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data else { return nil }
+        return try? JSONDecoder().decode(Value.self, from: data)
+    }
+
+    private static func saveValue(_ value: some Encodable, account: String) throws {
+        let data = try JSONEncoder().encode(value)
+        let query = baseQuery(account: account)
+        let attributes: [String: Any] = [kSecValueData as String: data]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecItemNotFound {
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw LongbridgeError.socket("keychain add failed (\(addStatus))")
+            }
+        } else if updateStatus != errSecSuccess {
+            throw LongbridgeError.socket("keychain update failed (\(updateStatus))")
+        }
+    }
+
+    private static func baseQuery(account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+}

--- a/Packages/PulseCore/Tests/PulseCoreTests/LongbridgeGatewayIntegrationTests.swift
+++ b/Packages/PulseCore/Tests/PulseCoreTests/LongbridgeGatewayIntegrationTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import PulseCore
+
+/// Live checks against the real Longbridge quote gateway. Skipped unless a socket OTP is
+/// supplied, so CI and normal test runs stay offline:
+///   LONGBRIDGE_TEST_OTP=xxx swift test --filter LongbridgeGatewayIntegrationTests
+@Suite("Longbridge gateway integration", .serialized)
+struct LongbridgeGatewayIntegrationTests {
+    static var otp: String? { ProcessInfo.processInfo.environment["LONGBRIDGE_TEST_OTP"] }
+
+    @Test(.enabled(if: otp != nil))
+    func authenticatesAndPullsQuoteAndCandles() async throws {
+        let otp = try #require(Self.otp)
+        let socket = LongbridgeSocket()
+        // Inject the externally-acquired OTP directly, bypassing the HTTP exchange.
+        await socket.updateOTPSource { otp }
+
+        // Quote pull (cmd 11)
+        let quoteBody = LongbridgeMessages.multiSecurityRequest(symbols: ["700.HK"])
+        let quoteResponse = try await socket.request(.querySecurityQuote, body: quoteBody)
+        let quotes = try LongbridgeMessages.decodeSecurityQuoteResponse(quoteResponse)
+        #expect(quotes.count == 1)
+        let quote = try #require(quotes.first)
+        #expect(quote.symbol == "700.HK")
+        let price = try #require(quote.lastDone)
+        #expect(price > 0)
+        print("[integration] 700.HK last_done=\(price) prev_close=\(quote.prevClose ?? 0) ts=\(quote.timestamp)")
+
+        // Candlestick pull (cmd 19) over the same authenticated connection
+        let candleBody = LongbridgeMessages.candlestickRequest(symbol: "700.HK", period: .minute5, count: 10)
+        let candleResponse = try await socket.request(.queryCandlestick, body: candleBody)
+        let candles = try LongbridgeMessages.decodeCandlestickResponse(candleResponse)
+        #expect(!candles.isEmpty)
+        #expect(candles.count <= 10)
+        let last = try #require(candles.last)
+        #expect(last.close > 0)
+        #expect(last.time.timeIntervalSinceNow > -24 * 3600)
+        print("[integration] candles=\(candles.count) last close=\(last.close) at \(last.time)")
+    }
+}

--- a/Packages/PulseCore/Tests/PulseCoreTests/LongbridgeOAuthTests.swift
+++ b/Packages/PulseCore/Tests/PulseCoreTests/LongbridgeOAuthTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import PulseCore
+
+@Suite("Longbridge OAuth")
+struct LongbridgeOAuthTests {
+    @Test func pkceChallengeMatchesRFC7636Vector() {
+        // RFC 7636 appendix B golden vector
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        #expect(LongbridgeOAuthAuthenticator.pkceChallenge(for: verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+    }
+
+    @Test func base64URLIsUnpaddedAndURLSafe() {
+        // 0xFB 0xEF 0xFF encodes to "++//" in plain base64
+        let encoded = LongbridgeOAuthAuthenticator.base64URL(Data([0xFB, 0xEF, 0xFF]))
+        #expect(encoded == "--__")
+        // 1 byte would need "==" padding in plain base64
+        #expect(LongbridgeOAuthAuthenticator.base64URL(Data([0x00])) == "AA")
+    }
+
+    @Test func randomURLSafeIsUniqueAndLongEnough() {
+        let a = LongbridgeOAuthAuthenticator.randomURLSafe(32)
+        let b = LongbridgeOAuthAuthenticator.randomURLSafe(32)
+        #expect(a != b)
+        #expect(a.count >= 43) // 32 bytes → 43 unpadded base64 chars
+    }
+
+    @Test func extractsCallbackQueryValues() throws {
+        let url = try #require(URL(string: "app.pulse.mac.dev://oauth/callback?code=abc123&state=xyz"))
+        #expect(LongbridgeOAuthAuthenticator.queryValue("code", in: url) == "abc123")
+        #expect(LongbridgeOAuthAuthenticator.queryValue("state", in: url) == "xyz")
+        #expect(LongbridgeOAuthAuthenticator.queryValue("missing", in: url) == nil)
+    }
+
+    @Test func callbackWithWrongStateIsRejected() async {
+        let authenticator = LongbridgeOAuthAuthenticator(redirectScheme: "test.scheme", clientName: "Test")
+        let url = URL(string: "test.scheme://oauth/callback?code=abc&state=forged")!
+        let consumed = await authenticator.handleCallback(url)
+        #expect(!consumed) // no pending flow, and a forged state must never resume one
+    }
+
+    @Test func parsesHTTPRequestTarget() {
+        let head = "GET /oauth/callback?code=abc&state=xyz HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        #expect(LongbridgeLoopbackServer.requestTarget(fromHead: head) == "/oauth/callback?code=abc&state=xyz")
+        #expect(LongbridgeLoopbackServer.requestTarget(fromHead: "POST /x HTTP/1.1\r\n") == nil)
+        #expect(LongbridgeLoopbackServer.requestTarget(fromHead: "") == nil)
+    }
+
+    /// Full loopback round trip in-process: bind, hit the callback with a real HTTP client,
+    /// and expect both the delivered URL and a human-readable success page.
+    @Test func loopbackServerDeliversCallbackAndSuccessPage() async throws {
+        let port: UInt16 = 41917
+        let received = LockedBox<URL>()
+        let server = LongbridgeLoopbackServer(port: port, callbackPath: "/oauth/callback") { url in
+            received.set(url)
+        }
+        try await server.start()
+        defer { Task { await server.stop() } }
+
+        let callbackURL = URL(string: "http://localhost:\(port)/oauth/callback?code=abc123&state=xyz")!
+        let (data, response) = try await URLSession.shared.data(from: callbackURL)
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        let html = String(decoding: data, as: UTF8.self)
+        #expect(html.contains("Pulse")) // page language follows the app setting; content itself is asserted below
+
+        let delivered = try #require(received.get())
+        #expect(LongbridgeOAuthAuthenticator.queryValue("code", in: delivered) == "abc123")
+        #expect(LongbridgeOAuthAuthenticator.queryValue("state", in: delivered) == "xyz")
+
+        // Unrelated paths must 404 without consuming the flow.
+        let (_, other) = try await URLSession.shared.data(from: URL(string: "http://localhost:\(port)/favicon.ico")!)
+        #expect((other as? HTTPURLResponse)?.statusCode == 404)
+    }
+
+    @Test func loopbackServerShowsCancelPageOnError() async throws {
+        let port: UInt16 = 41918 // separate port: tests may run in parallel
+        let server = LongbridgeLoopbackServer(port: port, callbackPath: "/oauth/callback") { _ in }
+        try await server.start()
+        defer { Task { await server.stop() } }
+
+        let denied = URL(string: "http://localhost:\(port)/oauth/callback?error=access_denied&state=xyz")!
+        let (data, _) = try await URLSession.shared.data(from: denied)
+        let html = String(decoding: data, as: UTF8.self)
+        #expect(html.contains("cancelled") || html.contains("授权未完成"))
+    }
+
+    @Test func resultPageRendersSingleLanguage() {
+        let zh = LongbridgeLoopbackServer.resultPage(denied: false, chinese: true)
+        #expect(zh.contains("授权成功"))
+        #expect(!zh.contains("Authorized"))
+        let en = LongbridgeLoopbackServer.resultPage(denied: true, chinese: false)
+        #expect(en.contains("Authorization cancelled"))
+        #expect(!en.contains("授权"))
+    }
+}
+
+/// Tiny thread-safe box for asserting values delivered from @Sendable callbacks.
+private final class LockedBox<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Value?
+
+    func set(_ new: Value) {
+        lock.withLock { value = new }
+    }
+
+    func get() -> Value? {
+        lock.withLock { value }
+    }
+}

--- a/Packages/PulseCore/Tests/PulseCoreTests/LongbridgeProtocolTests.swift
+++ b/Packages/PulseCore/Tests/PulseCoreTests/LongbridgeProtocolTests.swift
@@ -1,0 +1,304 @@
+import Foundation
+import Testing
+@testable import PulseCore
+
+@Suite("Longbridge protocol")
+struct LongbridgeProtocolTests {
+    // MARK: - Protobuf codec
+
+    @Test func protobufRoundTrip() throws {
+        var writer = ProtobufWriter()
+        writer.field(1, string: "700.HK")
+        writer.field(2, varint: 1000)
+        writer.field(7, int: 1_700_000_000)
+
+        var reader = ProtobufReader(writer.data)
+        var seen: [Int: ProtobufReader.Value] = [:]
+        while let field = try reader.nextField() {
+            seen[field.number] = field.value
+        }
+        #expect(seen[1]?.string == "700.HK")
+        #expect(seen[2]?.uint == 1000)
+        #expect(seen[7]?.int == 1_700_000_000)
+    }
+
+    @Test func protobufSkipsZeroFieldsLikeProto3() {
+        var writer = ProtobufWriter()
+        writer.field(1, varint: 0)
+        writer.field(2, string: "")
+        #expect(writer.data.isEmpty)
+    }
+
+    @Test func protobufMultiByteVarint() throws {
+        var writer = ProtobufWriter()
+        writer.field(3, varint: 300) // classic two-byte varint: 0xAC 0x02
+        var reader = ProtobufReader(writer.data)
+        let field = try #require(try reader.nextField())
+        #expect(field.number == 3)
+        #expect(field.value.uint == 300)
+    }
+
+    @Test func protobufRejectsTruncatedPayload() {
+        var writer = ProtobufWriter()
+        writer.field(1, string: "hello")
+        let truncated = writer.data.dropLast(2)
+        var reader = ProtobufReader(Data(truncated))
+        #expect(throws: ProtobufDecodingError.self) {
+            while try reader.nextField() != nil {}
+        }
+    }
+
+    // MARK: - Packet framing
+
+    @Test func requestFrameLayout() {
+        let body = Data([0xDE, 0xAD])
+        let frame = LongbridgePacket.encodeRequest(command: 11, requestID: 0x0102_0304, body: body, timeoutMS: 10_000)
+        #expect(Array(frame) == [
+            0x01,                     // type=1 in the low nibble, verify=0, gzip=0
+            11,                       // cmd
+            0x01, 0x02, 0x03, 0x04,   // request id (BE)
+            0x27, 0x10,               // timeout 10000ms (BE)
+            0x00, 0x00, 0x02,         // body_len u24
+            0xDE, 0xAD,
+        ])
+    }
+
+    @Test func matchesOfficialGoReferenceVector() {
+        // Golden vector from openapi-protocol/go/v1/header_test.go, "pack request should ok":
+        // Header{Type: 1, CmdCode: 1, RequestId: 1, Timeout: 0xff, BodyLength: 7}
+        let frame = LongbridgePacket.encodeRequest(command: 1, requestID: 1, body: Data(count: 7), timeoutMS: 0xFF)
+        #expect(Array(frame.prefix(11)) == [0b0000_0001, 0b0000_0001, 0, 0, 0, 1, 0, 0xFF, 0, 0, 7])
+    }
+
+    @Test func rejectsVerifiedPackets() {
+        // Response frame with verify=1 gzip=1 (0b00110010) from the Go reference tests:
+        // signed packets are not part of the OpenAPI quote gateway contract.
+        var frame = Data([0b0011_0010, 1, 0, 0, 0, 1, 8, 0, 0, 7])
+        frame.append(Data(count: 7))
+        #expect(throws: LongbridgePacket.FramingError.self) {
+            _ = try LongbridgePacket.decode(frame)
+        }
+    }
+
+    @Test func decodesResponseFrame() throws {
+        var body = ProtobufWriter()
+        body.field(1, string: "session-1")
+        var frame = Data([0x02, 2]) // type=2, cmd=auth
+        frame.append(contentsOf: [0, 0, 0, 1]) // request id 1
+        frame.append(0) // status success
+        let payload = body.data
+        frame.append(contentsOf: [0, 0, UInt8(payload.count)])
+        frame.append(payload)
+
+        let packets = try LongbridgePacket.decode(frame)
+        #expect(packets.count == 1)
+        guard case .response(let response) = try #require(packets.first) else {
+            Issue.record("expected response packet")
+            return
+        }
+        #expect(response.command == 2)
+        #expect(response.requestID == 1)
+        #expect(response.status == 0)
+        let auth = try LongbridgeMessages.AuthResponse(decoding: response.body)
+        #expect(auth.sessionID == "session-1")
+    }
+
+    @Test func decodesServerHeartbeatRequestAndPush() throws {
+        // Server-initiated heartbeat: type=1 frame that the client must echo back.
+        var frame = Data([0x01, 1])
+        frame.append(contentsOf: [0, 0, 0, 9])       // request id 9
+        frame.append(contentsOf: [0x00, 0x64])       // timeout
+        frame.append(contentsOf: [0, 0, 1, 0x2A])    // 1-byte body
+        // Push packet in the same websocket message.
+        frame.append(contentsOf: [0x03, 101, 0, 0, 0])
+
+        let packets = try LongbridgePacket.decode(frame)
+        #expect(packets.count == 2)
+        guard case .serverRequest(let command, let requestID, let body) = packets[0] else {
+            Issue.record("expected server request")
+            return
+        }
+        #expect(command == 1)
+        #expect(requestID == 9)
+        #expect(body == Data([0x2A]))
+        guard case .push(let push) = packets[1] else {
+            Issue.record("expected push")
+            return
+        }
+        #expect(push.command == 101)
+        #expect(push.body.isEmpty)
+    }
+
+    @Test func rejectsTruncatedFrame() {
+        let frame = Data([0x02, 2, 0, 0]) // response header cut short
+        #expect(throws: LongbridgePacket.FramingError.self) {
+            _ = try LongbridgePacket.decode(frame)
+        }
+    }
+
+    // MARK: - Quote payload decoding
+
+    @Test func decodesSecurityQuoteResponse() throws {
+        var pre = ProtobufWriter()
+        pre.field(1, string: "184.20")
+        pre.field(2, int: 1_700_000_100)
+        pre.field(7, string: "183.50")
+
+        var quote = ProtobufWriter()
+        quote.field(1, string: "AAPL.US")
+        quote.field(2, string: "183.50")
+        quote.field(3, string: "181.00")
+        quote.field(4, string: "182.10")
+        quote.field(7, int: 1_700_000_000)
+        quote.field(8, int: 52_000_000)
+        quote.field(9, string: "9500000000")
+        quote.field(11, message: pre)
+
+        var envelope = ProtobufWriter()
+        envelope.field(1, message: quote)
+
+        let quotes = try LongbridgeMessages.decodeSecurityQuoteResponse(envelope.data)
+        #expect(quotes.count == 1)
+        let wire = try #require(quotes.first)
+        #expect(wire.symbol == "AAPL.US")
+        #expect(wire.lastDone == 183.50)
+        #expect(wire.prevClose == 181.00)
+        #expect(wire.open == 182.10)
+        #expect(wire.volume == 52_000_000)
+        #expect(wire.turnover == 9_500_000_000)
+        #expect(wire.preMarket?.lastDone == 184.20)
+        #expect(wire.preMarket?.prevClose == 183.50)
+    }
+
+    @Test func decodesCandlestickResponse() throws {
+        var bar = ProtobufWriter()
+        bar.field(1, string: "456.8")   // close
+        bar.field(2, string: "455.0")   // open
+        bar.field(3, string: "454.2")   // low
+        bar.field(4, string: "457.6")   // high
+        bar.field(5, int: 1_234_567)
+        bar.field(7, int: 1_700_000_000)
+
+        var envelope = ProtobufWriter()
+        envelope.field(1, string: "700.HK")
+        envelope.field(2, message: bar)
+
+        let candles = try LongbridgeMessages.decodeCandlestickResponse(envelope.data)
+        #expect(candles.count == 1)
+        let candle = try #require(candles.first)
+        #expect(candle.close == 456.8)
+        #expect(candle.open == 455.0)
+        #expect(candle.low == 454.2)
+        #expect(candle.high == 457.6)
+        #expect(candle.volume == 1_234_567)
+        #expect(candle.time == Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    @Test func encodesAuthMetadataAsProtobufMap() throws {
+        let body = LongbridgeMessages.authRequest(otp: "otp-1", metadata: ["need_over_night_quote": "true"])
+        var reader = ProtobufReader(body)
+        var token = ""
+        var entries: [String: String] = [:]
+        while let field = try reader.nextField() {
+            switch field.number {
+            case 1:
+                token = field.value.string ?? ""
+            case 2:
+                var key = "", value = ""
+                var entry = ProtobufReader(try #require(field.value.data))
+                while let kv = try entry.nextField() {
+                    if kv.number == 1 { key = kv.value.string ?? "" }
+                    if kv.number == 2 { value = kv.value.string ?? "" }
+                }
+                entries[key] = value
+            default: break
+            }
+        }
+        #expect(token == "otp-1")
+        #expect(entries == ["need_over_night_quote": "true"])
+    }
+
+    @Test func encodesSubscribeAndDecodesPushQuote() throws {
+        // Subscribe payload round-trips through the codec with QUOTE type and first-push flag.
+        var reader = ProtobufReader(LongbridgeMessages.subscribeQuoteRequest(symbols: ["700.HK", "AAPL.US"]))
+        var symbols: [String] = []
+        var subTypes: [UInt64] = []
+        var firstPush: UInt64 = 0
+        while let field = try reader.nextField() {
+            switch field.number {
+            case 1: symbols.append(field.value.string ?? "")
+            case 2: subTypes.append(field.value.uint ?? 0)
+            case 3: firstPush = field.value.uint ?? 0
+            default: break
+            }
+        }
+        #expect(symbols == ["700.HK", "AAPL.US"])
+        #expect(subTypes == [1])
+        #expect(firstPush == 1)
+
+        // PushQuote decode, including the overnight session mapping.
+        var push = ProtobufWriter()
+        push.field(1, string: "AAPL.US")
+        push.field(3, string: "212.44")
+        push.field(7, int: 1_752_400_000)
+        push.field(8, int: 1_000)
+        push.field(11, varint: 3) // OVERNIGHT_TRADE
+        let decoded = try LongbridgeMessages.PushQuote(decoding: push.data)
+        #expect(decoded.symbol == "AAPL.US")
+        #expect(decoded.lastDone == 212.44)
+        #expect(decoded.timestamp == 1_752_400_000)
+        #expect(decoded.marketState == .overnight)
+    }
+
+    // MARK: - Gzip
+
+    @Test func gunzipInflatesGzipStream() throws {
+        // gzip of "pulse" produced by `printf pulse | gzip`
+        let gzipped = Data([
+            0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
+            0x2B, 0x28, 0xCD, 0x29, 0x4E, 0x05, 0x00,
+            0x21, 0x4E, 0x16, 0x9F, 0x05, 0x00, 0x00, 0x00,
+        ])
+        let inflated = try LongbridgePacket.gunzip(gzipped)
+        #expect(String(data: inflated, encoding: .utf8) == "pulse")
+    }
+
+    // MARK: - HTTP signature
+
+    @Test func signatureMatchesOfficialAlgorithm() {
+        // Golden vector computed with an independent implementation of
+        // openapi/rust/crates/httpclient/src/signature.rs
+        let credentials = LongbridgeCredentials(appKey: "test-key", appSecret: "test-secret", accessToken: "test-token")
+        let signature = LongbridgeHTTP.signature(
+            method: "GET", path: "/v1/socket/token", query: "",
+            credentials: credentials, timestamp: "1700000000", body: nil
+        )
+        #expect(signature == "HMAC-SHA256 SignedHeaders=authorization;x-api-key;x-timestamp, Signature=493263838237cabe767d080e56a492ce14b568066f7c54898f1e94b162cc47dd")
+    }
+
+    // MARK: - Symbol and quote mapping
+
+    @Test func mapsSymbolsToLongbridgeFormat() {
+        #expect(LongbridgeProvider.longbridgeSymbol(for: SymbolID(market: .hk, code: "700")) == "700.HK")
+        #expect(LongbridgeProvider.longbridgeSymbol(for: SymbolID(market: .us, code: "AAPL")) == "AAPL.US")
+        #expect(LongbridgeProvider.longbridgeSymbol(for: SymbolID(market: .sh, code: "603986")) == "603986.SH")
+        #expect(LongbridgeProvider.longbridgeSymbol(for: SymbolID(market: .sz, code: "300750")) == "300750.SZ")
+        #expect(LongbridgeProvider.longbridgeSymbol(for: SymbolID(market: .crypto, code: "BTC-USD")) == nil)
+    }
+
+    @Test func mapsWireQuoteToQuote() throws {
+        var wireData = ProtobufWriter()
+        wireData.field(1, string: "603986.SH")
+        wireData.field(2, string: "562.00")
+        wireData.field(3, string: "611.00")
+        wireData.field(7, int: 1_700_000_000)
+        let wire = try LongbridgeMessages.SecurityQuote(decoding: wireData.data)
+
+        let symbol = SymbolID(market: .sh, code: "603986")
+        let quote = try #require(LongbridgeProvider.quote(from: wire, symbol: symbol))
+        #expect(quote.price == 562.00)
+        #expect(quote.previousClose == 611.00)
+        #expect(quote.currencyCode == "CNY")
+        #expect(quote.timestamp == Date(timeIntervalSince1970: 1_700_000_000))
+    }
+}

--- a/PulseMac/Info.plist
+++ b/PulseMac/Info.plist
@@ -18,6 +18,17 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER).oauth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>

--- a/PulseMac/Pulse.entitlements
+++ b/PulseMac/Pulse.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>

--- a/PulseMac/Resources/en.lproj/Localizable.strings
+++ b/PulseMac/Resources/en.lproj/Localizable.strings
@@ -156,8 +156,9 @@
 
 "watchlist.menu.display" = "Display Metric";
 "watchlist.menu.sort" = "Sort By";
-"watchlist.sort.manual" = "Manual Order";
-"watchlist.sort.manualActive" = "Manual Order";
+"watchlist.sort.adjust" = "Adjust Order";
+"watchlist.sort.adjustActive" = "Adjusting Order";
+"watchlist.sort.manual" = "Custom Order";
 
 "watchRow.dragHelp" = "Drag to reorder";
 "watchRow.metricHelp" = "Click to cycle through Change %, Day P&L, and Total P&L";

--- a/PulseMac/Resources/en.lproj/Localizable.strings
+++ b/PulseMac/Resources/en.lproj/Localizable.strings
@@ -51,6 +51,7 @@
 "market.timeZone.utc" = "UTC";
 "market.us" = "US";
 
+"marketState.overnight" = "Overnight";
 "marketState.postMarket" = "Post";
 "marketState.preMarket" = "Pre";
 
@@ -86,9 +87,39 @@
 "provider.capability.quotes" = "Quotes";
 "provider.capability.search" = "Search";
 "provider.capability.streaming" = "Streaming";
+"provider.enable" = "Enable this source";
+"provider.refresh.interval" = "Poll interval";
+"provider.refresh.title" = "Refresh";
+"provider.refresh.push" = "Real-time push";
+"provider.status.on" = "On";
+"provider.status.off" = "Off";
+"provider.status.connected" = "Connected";
+"provider.status.notConnected" = "Not connected";
+"provider.detail.capabilities" = "Capabilities";
 "provider.composite" = "Pulse Composite";
 "provider.delay.delayed" = "Delayed";
-"provider.delay.realtime" = "Real-time available";
+"provider.delay.partial" = "Partially real-time";
+"provider.delay.realtime" = "Real-time";
+"provider.longbridge" = "Longbridge";
+"provider.longbridge.summary" = "Real-time HK/US/CN quotes with your own OpenAPI credentials";
+"longbridge.setup.manualToggle" = "Or enter API keys manually";
+"longbridge.setup.intro" = "Connect your Longbridge account to switch HK, US and CN quotes to real-time data.";
+"longbridge.disconnect" = "Disconnect";
+"longbridge.oauth.connect" = "Connect via Browser";
+"longbridge.oauth.waiting" = "Waiting for authorization…";
+"longbridge.oauth.error" = "Authorization failed or timed out — try again";
+"longbridge.account" = "Account";
+"longbridge.credentials.manual" = "Enter API keys manually";
+"longbridge.status.oauth" = "Connected (browser auth)";
+"longbridge.status.apiKey" = "Configured (API keys)";
+"longbridge.credentials.title" = "OpenAPI Credentials";
+"longbridge.credentials.status.configured" = "Configured";
+"longbridge.credentials.status.missing" = "Not configured";
+"longbridge.credentials.save" = "Save & Verify";
+"longbridge.credentials.validating" = "Verifying…";
+"longbridge.credentials.clear" = "Clear Credentials";
+"longbridge.credentials.error" = "Verification failed: check the credentials and whether the access token has expired";
+"longbridge.credentials.help" = "Get the App Key, App Secret and Access Token from the open.longbridge.com user center. Credentials are stored only in the local Keychain.";
 "provider.tencent" = "Tencent Finance";
 "provider.tencent.summary" = "Real-time A-share quotes and intraday charts";
 "provider.yahoo" = "Yahoo Finance";
@@ -97,6 +128,7 @@
 "quote.delay.minutes" = "Delayed ~%d min";
 "quote.price.close" = "Close";
 "quote.price.current" = "Price";
+"quote.price.overnight" = "Overnight";
 "quote.price.postMarket" = "Post-market";
 "quote.price.preMarket" = "Pre-market";
 "quote.realtime" = "Real-time";
@@ -120,7 +152,6 @@
 "settings.market.colorRule" = "Gain Color";
 "settings.market.greenUp" = "Green for Gains";
 "settings.market.redUp" = "Red for Gains";
-"settings.market.refreshInterval" = "Refresh Interval";
 "settings.menuBar.displayMode" = "Display Mode";
 "settings.menuBar.firstWatchlistItem" = "First in Watchlist";
 "settings.menuBar.fixedSymbol" = "Symbol";
@@ -151,6 +182,8 @@
 "stat.volume" = "Volume";
 
 "status.loading" = "Loading…";
+"status.healthy" = "Quotes healthy";
+"status.streaming" = "Streaming live";
 "status.providerFallback" = "Switching data source…";
 "status.reorderHint" = "Drag any row to reorder";
 

--- a/PulseMac/Resources/en.lproj/Localizable.strings
+++ b/PulseMac/Resources/en.lproj/Localizable.strings
@@ -101,7 +101,7 @@
 "provider.delay.partial" = "Partially real-time";
 "provider.delay.realtime" = "Real-time";
 "provider.longbridge" = "Longbridge";
-"provider.longbridge.summary" = "Real-time HK/US/CN quotes with your own OpenAPI credentials";
+"provider.longbridge.summary" = "Real-time quotes for HK, US and CN markets";
 "longbridge.setup.manualToggle" = "Or enter API keys manually";
 "longbridge.setup.intro" = "Connect your Longbridge account to switch HK, US and CN quotes to real-time data.";
 "longbridge.disconnect" = "Disconnect";

--- a/PulseMac/Resources/zh-Hans.lproj/Localizable.strings
+++ b/PulseMac/Resources/zh-Hans.lproj/Localizable.strings
@@ -101,7 +101,7 @@
 "provider.delay.partial" = "部分实时";
 "provider.delay.realtime" = "实时";
 "provider.longbridge" = "长桥 Longbridge";
-"provider.longbridge.summary" = "港美 A 股实时行情,需要你自己的 OpenAPI 凭证";
+"provider.longbridge.summary" = "港股、美股与 A 股实时行情";
 "longbridge.setup.manualToggle" = "或手动填入 API 密钥";
 "longbridge.setup.intro" = "连接你的 Longbridge 账户后,港股、美股与 A 股行情将切换为实时数据。";
 "longbridge.disconnect" = "断开连接";

--- a/PulseMac/Resources/zh-Hans.lproj/Localizable.strings
+++ b/PulseMac/Resources/zh-Hans.lproj/Localizable.strings
@@ -51,6 +51,7 @@
 "market.timeZone.utc" = "UTC 时间";
 "market.us" = "美股";
 
+"marketState.overnight" = "夜盘";
 "marketState.postMarket" = "盘后";
 "marketState.preMarket" = "盘前";
 
@@ -86,9 +87,39 @@
 "provider.capability.quotes" = "报价";
 "provider.capability.search" = "搜索";
 "provider.capability.streaming" = "推送";
+"provider.enable" = "启用此数据源";
+"provider.refresh.interval" = "轮询间隔";
+"provider.refresh.title" = "刷新方式";
+"provider.refresh.push" = "实时推送";
+"provider.status.on" = "已启用";
+"provider.status.off" = "已停用";
+"provider.status.connected" = "已连接";
+"provider.status.notConnected" = "未连接";
+"provider.detail.capabilities" = "能力";
 "provider.composite" = "Pulse 聚合";
 "provider.delay.delayed" = "延时";
-"provider.delay.realtime" = "部分实时";
+"provider.delay.partial" = "部分实时";
+"provider.delay.realtime" = "实时";
+"provider.longbridge" = "长桥 Longbridge";
+"provider.longbridge.summary" = "港美 A 股实时行情,需要你自己的 OpenAPI 凭证";
+"longbridge.setup.manualToggle" = "或手动填入 API 密钥";
+"longbridge.setup.intro" = "连接你的 Longbridge 账户后,港股、美股与 A 股行情将切换为实时数据。";
+"longbridge.disconnect" = "断开连接";
+"longbridge.oauth.connect" = "通过浏览器授权连接";
+"longbridge.oauth.waiting" = "等待浏览器授权…";
+"longbridge.oauth.error" = "授权失败或已超时,请重试";
+"longbridge.account" = "账户";
+"longbridge.credentials.manual" = "手动填入 API 密钥";
+"longbridge.status.oauth" = "已连接(浏览器授权)";
+"longbridge.status.apiKey" = "已配置(API 密钥)";
+"longbridge.credentials.title" = "OpenAPI 凭证";
+"longbridge.credentials.status.configured" = "已配置";
+"longbridge.credentials.status.missing" = "未配置";
+"longbridge.credentials.save" = "保存并校验";
+"longbridge.credentials.validating" = "正在校验…";
+"longbridge.credentials.clear" = "清除凭证";
+"longbridge.credentials.error" = "校验失败:请检查凭证是否正确、Access Token 是否过期";
+"longbridge.credentials.help" = "在 open.longbridge.com 用户中心获取 App Key、App Secret 与 Access Token。凭证仅保存在本机钥匙串。";
 "provider.tencent" = "腾讯行情";
 "provider.tencent.summary" = "A 股实时报价与分时图";
 "provider.yahoo" = "Yahoo Finance";
@@ -97,6 +128,7 @@
 "quote.delay.minutes" = "延时约%d分钟";
 "quote.price.close" = "收盘价";
 "quote.price.current" = "现价";
+"quote.price.overnight" = "夜盘价";
 "quote.price.postMarket" = "盘后价";
 "quote.price.preMarket" = "盘前价";
 "quote.realtime" = "实时";
@@ -120,7 +152,6 @@
 "settings.market.colorRule" = "涨跌颜色";
 "settings.market.greenUp" = "绿涨红跌";
 "settings.market.redUp" = "红涨绿跌";
-"settings.market.refreshInterval" = "盘中刷新频率";
 "settings.menuBar.displayMode" = "显示模式";
 "settings.menuBar.firstWatchlistItem" = "自选第一个";
 "settings.menuBar.fixedSymbol" = "固定标的";
@@ -151,6 +182,8 @@
 "stat.volume" = "成交量";
 
 "status.loading" = "加载中…";
+"status.healthy" = "行情正常";
+"status.streaming" = "实时推送中";
 "status.providerFallback" = "数据源异常，自动降级中";
 "status.reorderHint" = "拖动任意行调整顺序";
 

--- a/PulseMac/Resources/zh-Hans.lproj/Localizable.strings
+++ b/PulseMac/Resources/zh-Hans.lproj/Localizable.strings
@@ -156,8 +156,9 @@
 
 "watchlist.menu.display" = "列表显示";
 "watchlist.menu.sort" = "列表排序";
-"watchlist.sort.manual" = "手动排序";
-"watchlist.sort.manualActive" = "正在手动排序";
+"watchlist.sort.adjust" = "调整顺序";
+"watchlist.sort.adjustActive" = "正在调整顺序";
+"watchlist.sort.manual" = "自定义排序";
 
 "watchRow.dragHelp" = "按住拖动调整顺序";
 "watchRow.metricHelp" = "点击切换：涨跌幅 / 今日盈亏 / 持仓盈亏";

--- a/PulseMac/Sources/AppSettings.swift
+++ b/PulseMac/Sources/AppSettings.swift
@@ -64,6 +64,8 @@ extension MarketState {
             PulseLocalization.localizedString("marketState.preMarket")
         case .postMarket:
             PulseLocalization.localizedString("marketState.postMarket")
+        case .overnight:
+            PulseLocalization.localizedString("marketState.overnight")
         case .regular, .closed:
             nil
         }
@@ -80,7 +82,9 @@ final class AppSettings {
     /// The symbol pinned in single mode; nil falls back to the first watchlist item
     var primarySymbol: SymbolID? { didSet { save() } }
     var rotateInterval: TimeInterval = 6 { didSet { save() } }
-    var refreshInterval: TimeInterval = 15 { didSet { save() } }
+    /// Per-provider quote poll cadence overrides; a missing key falls back to the
+    /// provider's suggested interval. Replaces the former global refresh interval.
+    var providerPollIntervals: [String: TimeInterval] = [:] { didSet { save() } }
     var watchRowMetricMode: WatchRowMetricMode = .totalPnL { didSet { save() } }
     /// Red-up/green-down (A-share convention); false means green-up/red-down
     var redUp: Bool = true { didSet { save() } }
@@ -125,7 +129,7 @@ final class AppSettings {
             menuBarMode = snapshot.menuBarMode
             primarySymbol = snapshot.primarySymbol
             rotateInterval = snapshot.rotateInterval
-            refreshInterval = snapshot.refreshInterval
+            providerPollIntervals = snapshot.providerPollIntervals ?? [:]
             watchRowMetricMode = switch snapshot.watchRowMetricMode {
             case .changePercent, .todayPnL, .totalPnL:
                 snapshot.watchRowMetricMode!
@@ -147,21 +151,22 @@ final class AppSettings {
         var menuBarMode: MenuBarMode
         var primarySymbol: SymbolID?
         var rotateInterval: TimeInterval
-        var refreshInterval: TimeInterval
         var watchRowMetricMode: WatchRowMetricMode?
         var redUp: Bool
         var disabledProviderIDs: Set<String>?
         var showPriceInMenuBar: Bool?
         var languagePreference: PulseLanguagePreference?
+        var providerPollIntervals: [String: TimeInterval]?
     }
 
     private func save() {
         let snapshot = Snapshot(menuBarMode: menuBarMode, primarySymbol: primarySymbol,
-                                rotateInterval: rotateInterval, refreshInterval: refreshInterval,
+                                rotateInterval: rotateInterval,
                                 watchRowMetricMode: watchRowMetricMode, redUp: redUp,
                                 disabledProviderIDs: disabledProviderIDs,
                                 showPriceInMenuBar: showPriceInMenuBar,
-                                languagePreference: languagePreference)
+                                languagePreference: languagePreference,
+                                providerPollIntervals: providerPollIntervals)
         if let data = try? JSONEncoder().encode(snapshot) {
             defaults.set(data, forKey: storageKey)
         }

--- a/PulseMac/Sources/AppState.swift
+++ b/PulseMac/Sources/AppState.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 import PulseCore
@@ -11,6 +12,19 @@ final class AppState {
     let market: MarketStore
     let engine: RefreshEngine
     @ObservationIgnored let provider: CompositeProvider
+    @ObservationIgnored let longbridge: LongbridgeProvider
+    @ObservationIgnored let longbridgeOAuth: LongbridgeOAuthAuthenticator
+
+    enum LongbridgeAuthState {
+        case none
+        case apiKey
+        case oauth
+    }
+
+    /// Which Longbridge auth mode is active; `.none` keeps the provider out of routing
+    /// regardless of the user's enable toggle.
+    private(set) var longbridgeAuthState: LongbridgeAuthState
+    var longbridgeConfigured: Bool { longbridgeAuthState != .none }
 
     private(set) var rotationIndex = 0
     @ObservationIgnored private var rotationTask: Task<Void, Never>?
@@ -21,16 +35,46 @@ final class AppState {
         let settings = AppSettings()
         let watchlist = WatchlistStore()
         let market = MarketStore()
-        let provider = CompositeProvider(providers: [TencentProvider(), YahooProvider()],
-                                         disabledIDs: settings.disabledProviderIDs)
+        let (auth, authState) = Self.loadLongbridgeAuth()
+        let longbridge = LongbridgeProvider(auth: auth)
+        var disabledIDs = settings.disabledProviderIDs
+        if authState == .none { disabledIDs.insert(LongbridgeProvider.providerID) }
+        let provider = CompositeProvider(providers: [longbridge, TencentProvider(), YahooProvider()],
+                                         disabledIDs: disabledIDs)
         self.settings = settings
         self.watchlist = watchlist
         self.market = market
         self.provider = provider
+        self.longbridge = longbridge
+        self.longbridgeAuthState = authState
+        self.longbridgeOAuth = LongbridgeOAuthAuthenticator(
+            redirectScheme: Bundle.main.bundleIdentifier ?? "app.pulse.mac",
+            clientName: "Pulse"
+        )
         self.engine = RefreshEngine(provider: provider, store: market, watchlist: watchlist,
-                                    activeInterval: settings.refreshInterval)
+                                    pollOverrides: settings.providerPollIntervals)
         engine.start()
         startRotation()
+        observeMenuTracking()
+    }
+
+    /// OAuth tokens win over pasted API-key credentials when both exist.
+    private static func loadLongbridgeAuth() -> (LongbridgeAuth?, LongbridgeAuthState) {
+        if let tokens = LongbridgeCredentialStore.loadOAuthTokens() {
+            return (.oauth(Self.makeOAuthSession(tokens)), .oauth)
+        }
+        if let credentials = LongbridgeCredentialStore.load(), credentials.isComplete {
+            return (.apiKey(credentials), .apiKey)
+        }
+        return (nil, .none)
+    }
+
+    /// Refresh tokens rotate on every refresh; the session persists each rotation to the
+    /// Keychain immediately so the chain survives relaunches.
+    private static func makeOAuthSession(_ tokens: LongbridgeOAuthTokens) -> LongbridgeOAuthSession {
+        LongbridgeOAuthSession(tokens: tokens) { rotated in
+            try? LongbridgeCredentialStore.saveOAuthTokens(rotated)
+        }
     }
 
     // MARK: - Provider toggles
@@ -47,11 +91,73 @@ final class AppState {
         } else {
             settings.disabledProviderIDs.insert(id)
         }
-        let ids = settings.disabledProviderIDs
+        applyProviderAvailability()
+    }
+
+    /// User intent (enable toggles) combined with configuration state: an unconfigured
+    /// Longbridge never participates in routing.
+    private func effectiveDisabledIDs() -> Set<String> {
+        var ids = settings.disabledProviderIDs
+        if !longbridgeConfigured { ids.insert(LongbridgeProvider.providerID) }
+        return ids
+    }
+
+    private func applyProviderAvailability() {
+        let ids = effectiveDisabledIDs()
         Task {
             await provider.setDisabled(ids)
             engine.poke()
         }
+    }
+
+    // MARK: - Longbridge auth
+
+    /// Runs the browser OAuth flow end to end: authorize → validate against the live
+    /// gateway → persist. A failed attempt rolls back to whatever auth was active before.
+    func connectLongbridgeOAuth() async throws {
+        let tokens = try await longbridgeOAuth.authorize { url in
+            Task { @MainActor in NSWorkspace.shared.open(url) }
+        }
+        try await activate(auth: .oauth(Self.makeOAuthSession(tokens)))
+        try LongbridgeCredentialStore.saveOAuthTokens(tokens)
+        LongbridgeCredentialStore.clear() // OAuth replaces any pasted API-key credentials
+        longbridgeAuthState = .oauth
+        applyProviderAvailability()
+    }
+
+    /// Forwards `bundleid://oauth/callback?...` URLs from the system to the pending flow.
+    func handleOAuthCallback(_ url: URL) {
+        Task { _ = await longbridgeOAuth.handleCallback(url) }
+    }
+
+    /// Validates against the live gateway before persisting; invalid credentials are rolled
+    /// back so a previously working configuration is never destroyed by a failed edit.
+    func saveLongbridgeCredentials(_ credentials: LongbridgeCredentials) async throws {
+        try await activate(auth: .apiKey(credentials))
+        try LongbridgeCredentialStore.save(credentials)
+        LongbridgeCredentialStore.clearOAuthTokens() // manual credentials replace OAuth
+        longbridgeAuthState = .apiKey
+        applyProviderAvailability()
+    }
+
+    private func activate(auth: LongbridgeAuth) async throws {
+        await longbridge.updateAuth(auth)
+        do {
+            try await longbridge.validateConnection()
+        } catch {
+            await longbridge.updateAuth(Self.loadLongbridgeAuth().0)
+            throw error
+        }
+    }
+
+    func clearLongbridgeCredentials() {
+        LongbridgeCredentialStore.clear()
+        LongbridgeCredentialStore.clearOAuthTokens()
+        longbridgeAuthState = .none
+        Task {
+            await longbridge.updateAuth(nil)
+        }
+        applyProviderAvailability()
     }
 
     // MARK: - Menu bar text
@@ -106,9 +212,101 @@ final class AppState {
 
     // MARK: - Settings wiring
 
-    func applyRefreshInterval(_ interval: TimeInterval) {
-        settings.refreshInterval = interval
-        engine.activeInterval = interval
+    func pollInterval(for providerID: String) -> TimeInterval {
+        engine.pollInterval(for: providerID)
+    }
+
+    func setPollInterval(_ interval: TimeInterval, for providerID: String) {
+        settings.providerPollIntervals[providerID] = interval
+        engine.setPollOverride(interval, for: providerID)
+    }
+
+    // MARK: - Live watchlist (push-first home page)
+
+    @ObservationIgnored private var watchlistStreamTask: Task<Void, Never>?
+    @ObservationIgnored private var pendingPushes: [SymbolID: Quote] = [:]
+    @ObservationIgnored private var pushFlushTask: Task<Void, Never>?
+
+    /// While the popover is visible, every watchlist symbol served by a streaming source
+    /// ticks live; the rest keep their source's poll cadence. Closing the popover
+    /// unsubscribes — the menu bar text is fine at poll granularity.
+    func setPopoverVisible(_ visible: Bool) {
+        watchlistStreamTask?.cancel()
+        watchlistStreamTask = nil
+        guard visible else { return }
+        restartWatchlistStream()
+    }
+
+    /// Re-subscribes after watchlist edits while the popover is open.
+    func watchlistSymbolsChanged() {
+        guard watchlistStreamTask != nil else { return }
+        restartWatchlistStream()
+    }
+
+    /// True once the live stream has actually delivered a tick — proof of life, not just
+    /// "a subscription was attempted". Drives the footer's "streaming" status.
+    private(set) var liveStreaming = false
+
+    private func restartWatchlistStream() {
+        watchlistStreamTask?.cancel()
+        liveStreaming = false
+        let symbols = watchlist.symbols
+        guard !symbols.isEmpty, let stream = provider.quoteStream(for: symbols) else {
+            watchlistStreamTask = nil
+            return
+        }
+        watchlistStreamTask = Task { [weak self] in
+            defer { self?.liveStreaming = false }
+            do {
+                for try await quote in stream {
+                    self?.liveStreaming = true
+                    self?.ingestStreamedQuote(quote)
+                }
+            } catch {
+                // Stream dropped (socket reconnect etc.); polling still covers the list.
+            }
+        }
+    }
+
+    /// Pushes arrive per tick and per symbol; flushing them through a short buffer keeps a
+    /// busy market from re-rendering the list dozens of times per second. Detail-page
+    /// streams feed the same buffer so every push path shares the coalescing and gating.
+    func ingestStreamedQuote(_ quote: Quote) {
+        pendingPushes[quote.symbol] = quote
+        guard pushFlushTask == nil else { return }
+        pushFlushTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(250))
+            guard let self else { return }
+            self.pushFlushTask = nil
+            self.flushPendingPushes()
+        }
+    }
+
+    /// An open NSMenu (sort submenu, poll-interval picker, row context menu…) cannot survive
+    /// its host view being re-rendered every 250ms, so store writes hold while any menu
+    /// tracks; the buffer keeps absorbing ticks and flushes the moment tracking ends.
+    private func flushPendingPushes() {
+        guard menuTrackingDepth == 0, !pendingPushes.isEmpty else { return }
+        let batch = Array(pendingPushes.values)
+        pendingPushes = [:]
+        market.applyStreamed(batch)
+    }
+
+    @ObservationIgnored private var menuTrackingDepth = 0
+
+    private func observeMenuTracking() {
+        NotificationCenter.default.addObserver(forName: NSMenu.didBeginTrackingNotification,
+                                               object: nil, queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated { self?.menuTrackingDepth += 1 }
+        }
+        NotificationCenter.default.addObserver(forName: NSMenu.didEndTrackingNotification,
+                                               object: nil, queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.menuTrackingDepth = max(0, self.menuTrackingDepth - 1)
+                self.flushPendingPushes()
+            }
+        }
     }
 
     /// Minimum quote delay (in seconds) for a market: fallback only when the active quote source is unknown.
@@ -147,14 +345,6 @@ final class AppState {
         let delay = quoteDelay(for: quote)
         guard delay > 0 else { return nil }
         return PulseLocalization.localizedString("quote.delay.minutes", Int(delay / 60))
-    }
-
-    func refreshTimingText() -> String? {
-        guard let refreshed = market.lastRefresh else { return nil }
-        return PulseLocalization.localizedString(
-            "refresh.updatedAt",
-            refreshed.formatted(date: .omitted, time: .standard)
-        )
     }
 
     private func formatMarketTime(_ date: Date, market: Market) -> String {

--- a/PulseMac/Sources/AppState.swift
+++ b/PulseMac/Sources/AppState.swift
@@ -107,6 +107,10 @@ final class AppState {
         Task {
             await provider.setDisabled(ids)
             engine.poke()
+            // A push subscription checks availability only when it starts, so an
+            // already-running stream would keep delivering from a source the user
+            // just turned off — resubscribe against the new availability.
+            if watchlistStreamTask != nil { restartWatchlistStream() }
         }
     }
 
@@ -122,7 +126,9 @@ final class AppState {
         try LongbridgeCredentialStore.saveOAuthTokens(tokens)
         LongbridgeCredentialStore.clear() // OAuth replaces any pasted API-key credentials
         longbridgeAuthState = .oauth
-        applyProviderAvailability()
+        // Connecting is the strongest possible "turn this on" signal — flip the
+        // switch that was locked off while unconfigured.
+        setProvider(LongbridgeProvider.providerID, enabled: true)
     }
 
     /// Forwards `bundleid://oauth/callback?...` URLs from the system to the pending flow.
@@ -137,7 +143,7 @@ final class AppState {
         try LongbridgeCredentialStore.save(credentials)
         LongbridgeCredentialStore.clearOAuthTokens() // manual credentials replace OAuth
         longbridgeAuthState = .apiKey
-        applyProviderAvailability()
+        setProvider(LongbridgeProvider.providerID, enabled: true)
     }
 
     private func activate(auth: LongbridgeAuth) async throws {

--- a/PulseMac/Sources/DetailView.swift
+++ b/PulseMac/Sources/DetailView.swift
@@ -30,6 +30,19 @@ struct DetailView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .scrollEdgeEffectStyle(.soft, for: .all)
         .safeAreaInset(edge: .top, spacing: 0) { header }
+        // Real-time push while the page is on screen: each tick lands in the store, and the
+        // price / market-time views animate through their existing transitions. Closing the
+        // page cancels the task, which unsubscribes upstream; polling remains the fallback.
+        .task(id: symbol) {
+            guard let stream = appState.provider.quoteStream(for: [symbol]) else { return }
+            do {
+                for try await quote in stream {
+                    appState.ingestStreamedQuote(quote)
+                }
+            } catch {
+                // Stream dropped (e.g. socket reconnect) — the 15s polling loop still updates the page.
+            }
+        }
         .task(id: period) {
             let taskStart = ContinuousClock.now
             // Show the spinner only when loading is actually slow: a sub-150ms load
@@ -185,6 +198,10 @@ struct DetailView: View {
             }
             Text(appState.quoteMarketTimeText(for: quote))
                 .foregroundStyle(.tertiary)
+                .monospacedDigit()
+                // Market time ticks with real-time pushes; roll the digits like the price does.
+                .contentTransition(reduceMotion ? .opacity : .numericText())
+                .animation(.snappy(duration: 0.25), value: quote.timestamp)
         }
         .font(.system(size: 9, weight: .medium))
         .multilineTextAlignment(.trailing)
@@ -200,6 +217,8 @@ struct DetailView: View {
             PulseLocalization.localizedString("quote.price.preMarket")
         case .postMarket:
             PulseLocalization.localizedString("quote.price.postMarket")
+        case .overnight:
+            PulseLocalization.localizedString("quote.price.overnight")
         case .closed:
             PulseLocalization.localizedString("quote.price.close")
         case .regular, .none:

--- a/PulseMac/Sources/LongbridgeSetupView.swift
+++ b/PulseMac/Sources/LongbridgeSetupView.swift
@@ -1,0 +1,281 @@
+import SwiftUI
+import PulseCore
+
+/// Longbridge detail page, in the same card language as every other provider page:
+/// enable switch → shared fact card → an account card that carries the connection flow
+/// (browser OAuth as the primary action, manual API-key entry one level deeper).
+/// Secrets go to the Keychain only after a live validation round-trip; stored values are
+/// never displayed back, only overwritten.
+struct LongbridgeSetupView: View {
+    @Environment(AppState.self) private var appState
+    @Binding var route: PopoverRoute
+
+    @State private var showManualFields = false
+    @State private var appKey = ""
+    @State private var appSecret = ""
+    @State private var accessToken = ""
+    @State private var isConnecting = false
+    @State private var connectionError: String?
+    @FocusState private var focusedField: CredentialField?
+
+    private enum CredentialField {
+        case appKey, appSecret, accessToken
+    }
+
+    private var configured: Bool { appState.longbridgeConfigured }
+    private var enabled: Bool { appState.isProviderEnabled(LongbridgeProvider.providerID) }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(spacing: 14) {
+                    ProviderEnableCard(providerID: LongbridgeProvider.providerID)
+                        .padding(.top, 12)
+                    // A disabled source has nothing to connect: everything below collapses
+                    // with the switch instead of sitting around greyed out.
+                    if enabled {
+                        ProviderFactsCard(descriptor: appState.longbridge.descriptor)
+                        accountCard
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 16)
+                .frame(maxWidth: .infinity)
+            }
+            .onChange(of: showManualFields) { _, shown in
+                guard shown else { return }
+                focusedField = .appKey
+                // Let the expansion lay out first, then bring the fields into view.
+                Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(60))
+                    withAnimation(.snappy(duration: 0.25)) {
+                        proxy.scrollTo("manualFields", anchor: .bottom)
+                    }
+                }
+            }
+        }
+        .animation(.snappy(duration: 0.22), value: showManualFields)
+        .animation(.snappy(duration: 0.25), value: configured)
+        .animation(.snappy(duration: 0.25), value: enabled)
+        .scrollEdgeEffectStyle(.soft, for: .all)
+        .safeAreaInset(edge: .top, spacing: 0) { header }
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            IconButton(systemName: "chevron.left", help: PulseLocalization.localizedString("action.back")) {
+                route = .settings
+            }
+            Text(PulseLocalization.localizedString("provider.longbridge"))
+                .font(.system(size: 13, weight: .semibold))
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - Account card
+
+    private var accountCard: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(PulseLocalization.localizedString("longbridge.account"))
+                    .font(.system(size: 12, weight: .medium))
+                Spacer()
+                Circle()
+                    .fill(configured ? Color.green.opacity(0.85) : Color.secondary.opacity(0.35))
+                    .frame(width: 6, height: 6)
+                Text(PulseLocalization.localizedString(statusKey))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+
+            Divider().padding(.leading, 12)
+
+            VStack(spacing: 10) {
+                if configured {
+                    actionButton(titleKey: "longbridge.disconnect", tint: .red) {
+                        appState.clearLongbridgeCredentials()
+                        connectionError = nil
+                        showManualFields = false
+                    }
+                    .disabled(isConnecting)
+                } else {
+                    Text(PulseLocalization.localizedString("longbridge.setup.intro"))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    actionButton(
+                        titleKey: isConnecting ? "longbridge.oauth.waiting" : "longbridge.oauth.connect",
+                        tint: .accentColor,
+                        showsSpinner: isConnecting
+                    ) {
+                        connectOAuth()
+                    }
+                    .disabled(isConnecting)
+
+                    Button {
+                        showManualFields.toggle()
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text(PulseLocalization.localizedString("longbridge.setup.manualToggle"))
+                            Image(systemName: "chevron.down")
+                                .font(.system(size: 8, weight: .semibold))
+                                .rotationEffect(.degrees(showManualFields ? 180 : 0))
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.pressable)
+
+                    if showManualFields {
+                        manualFields
+                            .id("manualFields")
+                    }
+                }
+
+                if let connectionError {
+                    Text(connectionError)
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .padding(12)
+        }
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+    }
+
+    private var statusKey: String {
+        switch appState.longbridgeAuthState {
+        case .oauth: "longbridge.status.oauth"
+        case .apiKey: "longbridge.status.apiKey"
+        case .none: "provider.status.notConnected"
+        }
+    }
+
+    /// Full-width action in the app's quiet-surface idiom: tint lives in the text, feedback
+    /// lands on mouse-down via `.pressable` — no filled color slabs.
+    private func actionButton(titleKey: String, tint: Color, showsSpinner: Bool = false,
+                              action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                if showsSpinner {
+                    ProgressView().controlSize(.mini)
+                }
+                Text(PulseLocalization.localizedString(titleKey))
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundStyle(tint)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 30)
+            .background(.background.opacity(0.6), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .stroke(.separator.opacity(0.35), lineWidth: 0.5)
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.pressable)
+    }
+
+    // MARK: - Manual credentials (fallback)
+
+    private var manualFields: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            credentialField("App Key", text: $appKey, field: .appKey, secure: false)
+            credentialField("App Secret", text: $appSecret, field: .appSecret)
+            credentialField("Access Token", text: $accessToken, field: .accessToken)
+            HStack(alignment: .top) {
+                Text(PulseLocalization.localizedString("longbridge.credentials.help"))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 8)
+                Button(PulseLocalization.localizedString("longbridge.credentials.save")) {
+                    saveManualCredentials()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(!fieldsComplete || isConnecting)
+            }
+        }
+        .transition(.opacity.combined(with: .move(edge: .top)))
+    }
+
+    /// Text field in the app's own input idiom (the search field): plain field on a quiet
+    /// surface with a hairline separator stroke; the stroke picks up the accent on focus.
+    private func credentialField(_ placeholder: String, text: Binding<String>,
+                                 field: CredentialField, secure: Bool = true) -> some View {
+        Group {
+            if secure {
+                SecureField(placeholder, text: text)
+            } else {
+                TextField(placeholder, text: text)
+            }
+        }
+        .textFieldStyle(.plain)
+        .font(.system(size: 12))
+        .focused($focusedField, equals: field)
+        .padding(.horizontal, 9)
+        .frame(height: 26)
+        .background(.background.opacity(0.6), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(
+                    focusedField == field
+                        ? AnyShapeStyle(Color.accentColor.opacity(0.6))
+                        : AnyShapeStyle(.separator.opacity(0.35)),
+                    lineWidth: focusedField == field ? 1 : 0.5
+                )
+        }
+        .animation(.easeOut(duration: 0.15), value: focusedField == field)
+    }
+
+    private var fieldsComplete: Bool {
+        [appKey, appSecret, accessToken].allSatisfy { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+    }
+
+    // MARK: - Actions
+
+    private func connectOAuth() {
+        isConnecting = true
+        connectionError = nil
+        Task {
+            do {
+                try await appState.connectLongbridgeOAuth()
+                showManualFields = false
+            } catch {
+                connectionError = PulseLocalization.localizedString("longbridge.oauth.error")
+            }
+            isConnecting = false
+        }
+    }
+
+    private func saveManualCredentials() {
+        let credentials = LongbridgeCredentials(
+            appKey: appKey.trimmingCharacters(in: .whitespaces),
+            appSecret: appSecret.trimmingCharacters(in: .whitespaces),
+            accessToken: accessToken.trimmingCharacters(in: .whitespaces)
+        )
+        isConnecting = true
+        connectionError = nil
+        Task {
+            do {
+                try await appState.saveLongbridgeCredentials(credentials)
+                appKey = ""
+                appSecret = ""
+                accessToken = ""
+                showManualFields = false
+            } catch {
+                connectionError = PulseLocalization.localizedString("longbridge.credentials.error")
+            }
+            isConnecting = false
+        }
+    }
+}

--- a/PulseMac/Sources/LongbridgeSetupView.swift
+++ b/PulseMac/Sources/LongbridgeSetupView.swift
@@ -29,14 +29,17 @@ struct LongbridgeSetupView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 VStack(spacing: 14) {
-                    ProviderEnableCard(providerID: LongbridgeProvider.providerID)
+                    // The switch is locked until an account is connected; connecting
+                    // flips it on automatically, disconnecting locks it off again.
+                    ProviderEnableCard(providerID: LongbridgeProvider.providerID, locked: !configured)
                         .padding(.top, 12)
-                    // A disabled source has nothing to connect: everything below collapses
-                    // with the switch instead of sitting around greyed out.
-                    if enabled {
+                    // Behavior facts only apply to a source that is actually running.
+                    if configured && enabled {
                         ProviderFactsCard(descriptor: appState.longbridge.descriptor)
-                        accountCard
                     }
+                    // The account card always stays: it is the way in (connect) and
+                    // the way out (disconnect).
+                    accountCard
                 }
                 .padding(.horizontal, 16)
                 .padding(.bottom, 16)

--- a/PulseMac/Sources/PopoverRootView.swift
+++ b/PulseMac/Sources/PopoverRootView.swift
@@ -6,6 +6,7 @@ enum PopoverRoute: Hashable {
     case detail(SymbolID)
     case position(SymbolID, PositionReturnRoute)
     case settings
+    case providerDetail(String)
 }
 
 enum PositionReturnRoute: Hashable {
@@ -98,12 +99,28 @@ struct PopoverRootView: View {
                 SettingsView(route: $route)
                     .frame(height: height(for: route))
                     .transition(pushTransition)
+            case .providerDetail(let id):
+                Group {
+                    if id == LongbridgeProvider.providerID {
+                        LongbridgeSetupView(route: $route)
+                    } else if let descriptor = appState.providerDescriptors.first(where: { $0.id == id }) {
+                        ProviderDetailView(descriptor: descriptor, route: $route)
+                    }
+                }
+                .frame(height: height(for: route))
+                .transition(pushTransition)
             }
         }
         .frame(width: 340, height: height(for: route), alignment: .top)
         .clipped()
         .animation(.snappy(duration: 0.28), value: route)
         .animation(.snappy(duration: 0.28), value: height(for: route))
+        // Live subscriptions run only while the popover is on screen
+        .onAppear { appState.setPopoverVisible(true) }
+        .onDisappear { appState.setPopoverVisible(false) }
+        .onChange(of: appState.watchlist.symbols) { _, _ in
+            appState.watchlistSymbolsChanged()
+        }
     }
 
     /// The list page height adapts to the watchlist size (chrome, row height, bottom bar, and padding),
@@ -120,6 +137,8 @@ struct PopoverRootView: View {
             return 360
         case .settings:
             return 540
+        case .providerDetail(let id):
+            return id == LongbridgeProvider.providerID ? 410 : 320
         }
     }
 }

--- a/PulseMac/Sources/PopoverRootView.swift
+++ b/PulseMac/Sources/PopoverRootView.swift
@@ -137,8 +137,10 @@ struct PopoverRootView: View {
             return 360
         case .settings:
             return 540
-        case .providerDetail(let id):
-            return id == LongbridgeProvider.providerID ? 410 : 320
+        case .providerDetail:
+            // Same height as the settings page it navigates from, so the popover
+            // doesn't shrink on push and the taller pages don't need scrolling.
+            return 540
         }
     }
 }

--- a/PulseMac/Sources/ProviderDetailView.swift
+++ b/PulseMac/Sources/ProviderDetailView.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+import PulseCore
+
+/// Enable switch for a data source, presented as a quiet card at the top of its detail page.
+struct ProviderEnableCard: View {
+    @Environment(AppState.self) private var appState
+    let providerID: String
+
+    var body: some View {
+        // Full-width card, label leading and switch trailing — the same row anatomy as a
+        // grouped-settings toggle, so it aligns with the fact/benefit cards below it.
+        HStack {
+            Text(PulseLocalization.localizedString("provider.enable"))
+                .font(.system(size: 12, weight: .medium))
+            Spacer()
+            Toggle(isOn: Binding(
+                get: { appState.isProviderEnabled(providerID) },
+                set: { appState.setProvider(providerID, enabled: $0) }
+            )) {
+                EmptyView()
+            }
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.small)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+    }
+}
+
+/// Detail page for data sources without a connection flow (Tencent, Yahoo): the enable
+/// switch plus a fact card describing what the source covers.
+struct ProviderDetailView: View {
+    @Environment(AppState.self) private var appState
+    let descriptor: ProviderDescriptor
+    @Binding var route: PopoverRoute
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 14) {
+                ProviderEnableCard(providerID: descriptor.id)
+                    .padding(.top, 12)
+                ProviderFactsCard(descriptor: descriptor)
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
+            .frame(maxWidth: .infinity)
+        }
+        .scrollEdgeEffectStyle(.soft, for: .all)
+        .safeAreaInset(edge: .top, spacing: 0) { header }
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            IconButton(systemName: "chevron.left", help: PulseLocalization.localizedString("action.back")) {
+                route = .settings
+            }
+            Text(descriptor.name)
+                .font(.system(size: 13, weight: .semibold))
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+    }
+}
+
+/// Fact card shared by every provider detail page: capabilities, how the app refreshes
+/// from this source, then one row per covered market spelling out its exact source
+/// freshness — "实时" or the concrete delay in minutes.
+struct ProviderFactsCard: View {
+    @Environment(AppState.self) private var appState
+    let descriptor: ProviderDescriptor
+
+    var body: some View {
+        VStack(spacing: 0) {
+            factRow(PulseLocalization.localizedString("provider.detail.capabilities")) {
+                Text(capabilities)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.trailing)
+            }
+            if descriptor.capabilities.contains(.streaming), appState.longbridgeConfigured {
+                Divider().padding(.leading, 12)
+                factRow(PulseLocalization.localizedString("provider.refresh.title")) {
+                    Text(PulseLocalization.localizedString("provider.refresh.push"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Divider().padding(.leading, 12)
+            // Source latency (the per-market rows below) and poll cadence are different
+            // dimensions: a zero-delay source polled every 60s still moves in 60s steps.
+            factRow(PulseLocalization.localizedString("provider.refresh.interval")) {
+                Picker("", selection: Binding(
+                    get: { Int(appState.pollInterval(for: descriptor.id)) },
+                    set: { appState.setPollInterval(TimeInterval($0), for: descriptor.id) }
+                )) {
+                    ForEach([5, 15, 30, 60], id: \.self) { seconds in
+                        Text(PulseLocalization.localizedString("duration.seconds", seconds)).tag(seconds)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .controlSize(.small)
+                .fixedSize()
+            }
+            ForEach(coveredMarkets, id: \.self) { market in
+                Divider().padding(.leading, 12)
+                factRow(market.displayName) {
+                    freshnessLabel(for: descriptor.delay[market] ?? 0)
+                }
+            }
+        }
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+    }
+
+    private func factRow(_ title: String, @ViewBuilder value: () -> some View) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(title)
+                .font(.system(size: 12, weight: .medium))
+            Spacer(minLength: 12)
+            value()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+    }
+
+    private func freshnessLabel(for delay: TimeInterval) -> some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(delay == 0 ? Color.green.opacity(0.8) : .orange)
+                .frame(width: 5, height: 5)
+            Text(delay == 0
+                ? PulseLocalization.localizedString("provider.delay.realtime")
+                : PulseLocalization.localizedString("quote.delay.minutes", Int(delay / 60)))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var coveredMarkets: [Market] {
+        Market.allCases.filter { descriptor.markets.contains($0) }
+    }
+
+    private var capabilities: String {
+        var parts: [String] = []
+        if descriptor.capabilities.contains(.quotes) {
+            parts.append(PulseLocalization.localizedString("provider.capability.quotes"))
+        }
+        if descriptor.capabilities.contains(.candles) {
+            parts.append(PulseLocalization.localizedString("provider.capability.candles"))
+        }
+        if descriptor.capabilities.contains(.search) {
+            parts.append(PulseLocalization.localizedString("provider.capability.search"))
+        }
+        if descriptor.capabilities.contains(.streaming) {
+            parts.append(PulseLocalization.localizedString("provider.capability.streaming"))
+        }
+        return parts.joined(separator: ", ")
+    }
+}

--- a/PulseMac/Sources/ProviderDetailView.swift
+++ b/PulseMac/Sources/ProviderDetailView.swift
@@ -5,6 +5,9 @@ import PulseCore
 struct ProviderEnableCard: View {
     @Environment(AppState.self) private var appState
     let providerID: String
+    /// Connectable sources lock the switch off until an account is connected:
+    /// there is nothing an unconnected source could be "on" for.
+    var locked: Bool = false
 
     var body: some View {
         // Full-width card, label leading and switch trailing — the same row anatomy as a
@@ -14,7 +17,7 @@ struct ProviderEnableCard: View {
                 .font(.system(size: 12, weight: .medium))
             Spacer()
             Toggle(isOn: Binding(
-                get: { appState.isProviderEnabled(providerID) },
+                get: { !locked && appState.isProviderEnabled(providerID) },
                 set: { appState.setProvider(providerID, enabled: $0) }
             )) {
                 EmptyView()
@@ -22,6 +25,7 @@ struct ProviderEnableCard: View {
             .labelsHidden()
             .toggleStyle(.switch)
             .controlSize(.small)
+            .disabled(locked)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 9)

--- a/PulseMac/Sources/PulseMacApp.swift
+++ b/PulseMac/Sources/PulseMacApp.swift
@@ -1,13 +1,31 @@
 import SwiftUI
 import PulseCore
 
+/// Receives custom-scheme URLs (the Longbridge OAuth callback). A menu bar app's popover
+/// view hierarchy may not be alive when the browser redirects back, so the app delegate is
+/// the reliable entry point rather than `onOpenURL`.
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    static var urlHandler: ((URL) -> Void)?
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        for url in urls {
+            Self.urlHandler?(url)
+        }
+    }
+}
+
 @main
 struct PulseMacApp: App {
-    @State private var appState = AppState()
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    @State private var appState: AppState
 
     init() {
         SelfTest.runIfRequested()
         SoftwareUpdateController.shared.start()
+        let state = AppState()
+        _appState = State(initialValue: state)
+        AppDelegate.urlHandler = { url in state.handleOAuthCallback(url) }
     }
 
     var body: some Scene {

--- a/PulseMac/Sources/SettingsView.swift
+++ b/PulseMac/Sources/SettingsView.swift
@@ -1,22 +1,46 @@
 import SwiftUI
 import PulseCore
 
+/// One data source in the settings list: a plain navigation row (name, summary, state, ›).
+/// The enable switch and any connection flow live on the source's own detail page, so every
+/// provider — connectable or not — shares one row shape and one behavior.
 struct ProviderRow: View {
     @Environment(AppState.self) private var appState
     let descriptor: ProviderDescriptor
+    let onOpen: () -> Void
 
     var body: some View {
-        Toggle(isOn: Binding(
-            get: { appState.isProviderEnabled(descriptor.id) },
-            set: { appState.setProvider(descriptor.id, enabled: $0) }
-        )) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(descriptor.name)
-                Text(summary)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+        Button(action: onOpen) {
+            HStack(spacing: 6) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(descriptor.name)
+                    Text(summary)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(PulseLocalization.localizedString(statusKey))
+                    .font(.caption)
+                    .foregroundStyle(statusIsPositive ? AnyShapeStyle(Color.green) : AnyShapeStyle(.secondary))
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.tertiary)
             }
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+    }
+
+    private var isConnectable: Bool { !descriptor.credentials.isEmpty }
+
+    private var statusKey: String {
+        guard appState.isProviderEnabled(descriptor.id) else { return "provider.status.off" }
+        guard isConnectable else { return "provider.status.on" }
+        return appState.longbridgeConfigured ? "provider.status.connected" : "provider.status.notConnected"
+    }
+
+    private var statusIsPositive: Bool {
+        isConnectable && appState.isProviderEnabled(descriptor.id) && appState.longbridgeConfigured
     }
 
     private var summary: String {
@@ -43,9 +67,11 @@ struct ProviderRow: View {
         if descriptor.capabilities.contains(.streaming) {
             capabilities.append(PulseLocalization.localizedString("provider.capability.streaming"))
         }
-        let realtime = descriptor.delay.contains { $0.value == 0 }
-            ? PulseLocalization.localizedString("provider.delay.realtime")
-            : PulseLocalization.localizedString("provider.delay.delayed")
+        let realtime = switch descriptor.delayClass {
+        case .realtime: PulseLocalization.localizedString("provider.delay.realtime")
+        case .partiallyRealtime: PulseLocalization.localizedString("provider.delay.partial")
+        case .delayed: PulseLocalization.localizedString("provider.delay.delayed")
+        }
         return "\(markets) · \(capabilities.joined(separator: ", ")) · \(realtime)"
     }
 }
@@ -91,15 +117,8 @@ struct SettingsView: View {
             }
 
             Section(PulseLocalization.localizedString("settings.section.market")) {
-                Picker(PulseLocalization.localizedString("settings.market.refreshInterval"), selection: Binding(
-                    get: { settings.refreshInterval },
-                    set: { appState.applyRefreshInterval($0) }
-                )) {
-                    Text(PulseLocalization.localizedString("duration.seconds", 5)).tag(TimeInterval(5))
-                    Text(PulseLocalization.localizedString("duration.seconds", 15)).tag(TimeInterval(15))
-                    Text(PulseLocalization.localizedString("duration.seconds", 30)).tag(TimeInterval(30))
-                    Text(PulseLocalization.localizedString("duration.seconds", 60)).tag(TimeInterval(60))
-                }
+                // Refresh cadence moved to each data source's detail page — sources have
+                // very different politeness budgets, so a global interval stopped making sense.
                 Picker(PulseLocalization.localizedString("settings.market.colorRule"), selection: $settings.redUp) {
                     Text(PulseLocalization.localizedString("settings.market.redUp")).tag(true)
                     Text(PulseLocalization.localizedString("settings.market.greenUp")).tag(false)
@@ -108,7 +127,9 @@ struct SettingsView: View {
 
             Section {
                 ForEach(appState.providerDescriptors, id: \.id) { descriptor in
-                    ProviderRow(descriptor: descriptor)
+                    ProviderRow(descriptor: descriptor) {
+                        route = .providerDetail(descriptor.id)
+                    }
                 }
             } header: {
                 Text(PulseLocalization.localizedString("settings.section.providers"))

--- a/PulseMac/Sources/SettingsView.swift
+++ b/PulseMac/Sources/SettingsView.swift
@@ -34,9 +34,11 @@ struct ProviderRow: View {
     private var isConnectable: Bool { !descriptor.credentials.isEmpty }
 
     private var statusKey: String {
+        // An unconnected account outranks the stored toggle: the switch is locked
+        // until a connection exists, so "not connected" is the only honest state.
+        if isConnectable && !appState.longbridgeConfigured { return "provider.status.notConnected" }
         guard appState.isProviderEnabled(descriptor.id) else { return "provider.status.off" }
-        guard isConnectable else { return "provider.status.on" }
-        return appState.longbridgeConfigured ? "provider.status.connected" : "provider.status.notConnected"
+        return isConnectable ? "provider.status.connected" : "provider.status.on"
     }
 
     private var statusIsPositive: Bool {

--- a/PulseMac/Sources/Sharing/WatchlistShareSnapshot.swift
+++ b/PulseMac/Sources/Sharing/WatchlistShareSnapshot.swift
@@ -85,8 +85,11 @@ struct WatchlistShareSnapshot {
             )
         }
         redUp = appState.settings.redUp
-        updatedAtText = appState.refreshTimingText()
-            ?? PulseLocalization.localizedString("share.updateUnavailable")
+        // The card is rendered from live store data, so its freshness is the capture moment
+        updatedAtText = PulseLocalization.localizedString(
+            "refresh.updatedAt",
+            Date.now.formatted(date: .omitted, time: .standard)
+        )
     }
 }
 

--- a/PulseMac/Sources/WatchlistView.swift
+++ b/PulseMac/Sources/WatchlistView.swift
@@ -76,7 +76,8 @@ struct WatchlistView: View {
                 Image(systemName: "waveform.path.ecg")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.tint)
-                Text("Pulse")
+                // Bundle display name: "Pulse Dev" in Debug builds, "Pulse" in Release
+                Text(Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "Pulse")
                     .font(.system(size: 12.5, weight: .semibold))
                 Spacer()
                 ClusterMenu(systemName: "ellipsis.circle", help: PulseLocalization.localizedString("action.more")) {
@@ -191,9 +192,9 @@ struct WatchlistView: View {
         return widths.max() ?? 48
     }
 
-    /// Status line with the manual-refresh button beside it: freshness info and the action to renew it live together.
-    /// While reordering it carries the drag hint alone — the status dot and refresh button hide so the
-    /// line reads as instruction, not as data-freshness state.
+    /// Health line with the manual-refresh button beside it. With per-provider cadences and
+    /// push updates there is no single "refreshed at" moment anymore, so the line carries
+    /// health only: a status dot, plus the fallback notice when a source is failing.
     private var footer: some View {
         HStack(spacing: 5) {
             if isReordering {
@@ -202,14 +203,12 @@ struct WatchlistView: View {
                 Circle()
                     .fill(appState.market.lastError == nil ? Color.green.opacity(0.8) : .orange)
                     .frame(width: 6, height: 6)
-                Group {
-                    if appState.market.lastError != nil {
-                        Text(PulseLocalization.localizedString("status.providerFallback"))
-                    } else if let timing = appState.refreshTimingText() {
-                        Text(timing)
-                    } else {
-                        Text(PulseLocalization.localizedString("status.loading"))
-                    }
+                if appState.market.lastError != nil {
+                    Text(PulseLocalization.localizedString("status.providerFallback"))
+                } else if appState.liveStreaming {
+                    Text(PulseLocalization.localizedString("status.streaming"))
+                } else {
+                    Text(PulseLocalization.localizedString("status.healthy"))
                 }
                 Button {
                     appState.engine.poke()

--- a/PulseMac/Sources/WatchlistView.swift
+++ b/PulseMac/Sources/WatchlistView.swift
@@ -99,10 +99,9 @@ struct WatchlistView: View {
                     }
                     Divider()
                     Menu {
+                        // State group: where the current order comes from (checkmark semantics).
                         Toggle(
-                            isReordering
-                                ? PulseLocalization.localizedString("watchlist.sort.manualActive")
-                                : PulseLocalization.localizedString("watchlist.sort.manual"),
+                            PulseLocalization.localizedString("watchlist.sort.manual"),
                             isOn: orderModeBinding(.manual)
                         )
 
@@ -111,6 +110,18 @@ struct WatchlistView: View {
                         ForEach(WatchlistSortOption.allCases) { option in
                             Toggle(option.title, isOn: sortOptionBinding(option))
                         }
+
+                        Divider()
+
+                        // Action: enter the drag-to-reorder state for the arrangement on screen.
+                        Button {
+                            beginAdjustingOrder()
+                        } label: {
+                            Text(PulseLocalization.localizedString(
+                                isReordering ? "watchlist.sort.adjustActive" : "watchlist.sort.adjust"
+                            ))
+                        }
+                        .disabled(isReordering)
                     } label: {
                         Text(PulseLocalization.localizedString("watchlist.menu.sort"))
                     }
@@ -181,37 +192,41 @@ struct WatchlistView: View {
     }
 
     /// Status line with the manual-refresh button beside it: freshness info and the action to renew it live together.
+    /// While reordering it carries the drag hint alone — the status dot and refresh button hide so the
+    /// line reads as instruction, not as data-freshness state.
     private var footer: some View {
         HStack(spacing: 5) {
-            Circle()
-                .fill(appState.market.lastError == nil ? Color.green.opacity(0.8) : .orange)
-                .frame(width: 6, height: 6)
-            Group {
-                if isReordering {
-                    Text(PulseLocalization.localizedString("status.reorderHint"))
-                } else if appState.market.lastError != nil {
-                    Text(PulseLocalization.localizedString("status.providerFallback"))
-                } else if let timing = appState.refreshTimingText() {
-                    Text(timing)
-                } else {
-                    Text(PulseLocalization.localizedString("status.loading"))
+            if isReordering {
+                Text(PulseLocalization.localizedString("status.reorderHint"))
+            } else {
+                Circle()
+                    .fill(appState.market.lastError == nil ? Color.green.opacity(0.8) : .orange)
+                    .frame(width: 6, height: 6)
+                Group {
+                    if appState.market.lastError != nil {
+                        Text(PulseLocalization.localizedString("status.providerFallback"))
+                    } else if let timing = appState.refreshTimingText() {
+                        Text(timing)
+                    } else {
+                        Text(PulseLocalization.localizedString("status.loading"))
+                    }
                 }
+                Button {
+                    appState.engine.poke()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(refreshHovering ? .primary : .secondary)
+                        .frame(width: 16, height: 16)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                .fill(refreshHovering ? Color.primary.opacity(0.08) : .clear)
+                        )
+                }
+                .buttonStyle(.pressable)
+                .onHover { refreshHovering = $0 }
+                .help(PulseLocalization.localizedString("action.refreshNow"))
             }
-            Button {
-                appState.engine.poke()
-            } label: {
-                Image(systemName: "arrow.clockwise")
-                    .font(.system(size: 9, weight: .medium))
-                    .foregroundStyle(refreshHovering ? .primary : .secondary)
-                    .frame(width: 16, height: 16)
-                    .background(
-                        RoundedRectangle(cornerRadius: 4, style: .continuous)
-                            .fill(refreshHovering ? Color.primary.opacity(0.08) : .clear)
-                    )
-            }
-            .buttonStyle(.pressable)
-            .onHover { refreshHovering = $0 }
-            .help(PulseLocalization.localizedString("action.refreshNow"))
         }
         .font(.caption2)
         .foregroundStyle(.secondary)
@@ -484,12 +499,20 @@ struct WatchlistView: View {
         .scrollContentBackground(.hidden)
     }
 
-    private func enterManualReorderMode() {
+    /// State switch: bring back the remembered custom order. Does not enter the reorder UI.
+    private func selectCustomOrder() {
         searchText = ""
         withAnimation(.snappy(duration: 0.16)) {
             _ = appState.watchlist.restoreManualOrder()
         }
         listOrderMode = WatchlistOrderMode.manual.rawValue
+    }
+
+    /// Action: start adjusting the arrangement currently on screen. Order mode and the remembered
+    /// custom order stay untouched until the first actual drag (onMove commits both), so exiting
+    /// without dragging changes nothing.
+    private func beginAdjustingOrder() {
+        searchText = ""
         withAnimation(.snappy(duration: 0.25)) { isReordering = true }
     }
 
@@ -540,11 +563,12 @@ struct WatchlistView: View {
     private func orderModeBinding(_ mode: WatchlistOrderMode) -> Binding<Bool> {
         Binding(
             get: { listOrderMode == mode.rawValue },
-            set: { isSelected in
-                guard isSelected else { return }
+            // Menu radio semantics: selecting an item always fires, even when already checked
+            // (a checked Toggle sends `false` on click). Restoring is idempotent, so this is safe.
+            set: { _ in
                 switch mode {
                 case .manual:
-                    enterManualReorderMode()
+                    selectCustomOrder()
                 case .automatic:
                     break
                 }

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Pulse is a lightweight market-watching app, not a trading terminal. It solves ex
 - **Watchlist** supporting US stocks, Hong Kong stocks, China A-shares, cryptocurrencies, indices, and ETFs — add by ticker, name, or pinyin search
 - **Position tracking**: quantity, cost basis, market value, daily P&L, and total P&L
 - **Quote detail view**: price, change, OHLC, volume, amplitude, realtime / delayed status, quote source, and market-specific timestamp in a dense menu-bar layout
-- **Charts**: realtime Tencent intraday lines for China A-shares, plus Yahoo-backed daily / weekly / monthly candlesticks with OHLC and volume
+- **Charts**: intraday lines and daily / weekly / monthly candlesticks with OHLC and volume, sourced from the best available provider per market
 - **Share images**: copy a branded, mobile-friendly watchlist image that follows the current metric selection and adapts to list length
 - **Multi-provider data layer**: providers are routed per market, cached to reduce duplicate requests, and fail over automatically when one is rate-limited or down
-- **Trading-session-aware refresh**: polls only while each market is open, following its trading calendar — saving power and avoiding rate limits
+- **Real-time via Longbridge**: optionally connect your own [Longbridge](https://open.longbridge.com) account (browser authorization or API keys) to upgrade HK / US / A-share quotes to official real-time data, streamed live over a push connection — including the US overnight session
+- **Session-aware, per-source refresh**: each provider polls at its own configurable cadence, and only while its markets are open — saving power and avoiding rate limits; push-capable sources stream instead of polling
 - **Language control**: follows the system language when possible, with manual switching between English and Simplified Chinese
 
 ## Installation
@@ -50,13 +51,13 @@ PULSE_LIVE_TESTS=1 swift test
 - **`Packages/PulseUI`** — shared SwiftUI components: candlestick chart, intraday chart, sparkline, gain/loss colors.
 - **`PulseMac`** — the macOS menu bar app (`MenuBarExtra`, `LSUIElement=true`).
 
-All market data flows through the `QuoteProvider` protocol abstraction. A `CompositeProvider` routes requests per market and candle period, caches recent responses, breaks the circuit on unhealthy providers, and composes data from multiple sources (e.g. realtime A-share quotes and intraday lines from Tencent, historical candles and cryptocurrency coverage from Yahoo).
+All market data flows through the `QuoteProvider` protocol abstraction. A `CompositeProvider` routes requests per market and candle period, caches recent responses, breaks the circuit on unhealthy providers, and composes data from multiple sources (e.g. realtime A-share quotes and intraday lines from Tencent, historical candles and cryptocurrency coverage from Yahoo, real-time streaming across markets from a connected Longbridge account). The Longbridge integration speaks the OpenAPI binary WebSocket protocol directly — no SDK dependency — and stores credentials only in the local Keychain.
 
-Quotes carry their active source and source-specific delay metadata through the app. The watchlist footer shows the app refresh time, while each symbol detail view shows that symbol's realtime / delayed status, active source, and market timestamp with the relevant time basis.
+Quotes carry their active source and source-specific delay metadata through the app. The watchlist footer shows the live feed status, while each symbol detail view shows that symbol's realtime / delayed status, active source, and market timestamp with the relevant time basis.
 
 ## Data Sources & Disclaimer
 
-Pulse currently uses **free, unofficial** quote endpoints from Yahoo Finance and Tencent. These come with no SLA and may be rate-limited or change without notice. Quote delay varies by provider and market; delayed sources are labeled in the UI when the provider exposes that metadata. All data is for reference only and is **not investment advice**.
+Out of the box, Pulse uses **free, unofficial** quote endpoints from Yahoo Finance and Tencent. These come with no SLA and may be rate-limited or change without notice. Optionally, you can connect your own **Longbridge OpenAPI** account for official real-time quotes delivered by push; quote entitlements follow your account, and credentials never leave the local Keychain. Quote delay varies by provider and market; each source's per-market freshness is spelled out on its detail page. All data is for reference only and is **not investment advice**.
 
 ## License
 

--- a/project.yml
+++ b/project.yml
@@ -41,11 +41,19 @@ targets:
         SUFeedURL: $(SPARKLE_FEED_URL)
         SUPublicEDKey: $(SPARKLE_PUBLIC_ED_KEY)
         SUScheduledCheckInterval: 86400
+        # Longbridge OAuth fallback callback (bundle id doubles as the URL scheme,
+        # keeping dev and release callbacks isolated)
+        CFBundleURLTypes:
+          - CFBundleURLName: $(PRODUCT_BUNDLE_IDENTIFIER).oauth
+            CFBundleURLSchemes:
+              - $(PRODUCT_BUNDLE_IDENTIFIER)
     entitlements:
       path: PulseMac/Pulse.entitlements
       properties:
         com.apple.security.app-sandbox: true
         com.apple.security.network.client: true
+        # Loopback listener for the Longbridge OAuth redirect (primary callback path)
+        com.apple.security.network.server: true
         com.apple.security.temporary-exception.mach-lookup.global-name:
           - $(PRODUCT_BUNDLE_IDENTIFIER)-spks
           - $(PRODUCT_BUNDLE_IDENTIFIER)-spki

--- a/project.yml
+++ b/project.yml
@@ -59,7 +59,7 @@ targets:
           - $(PRODUCT_BUNDLE_IDENTIFIER)-spki
     settings:
       base:
-        MARKETING_VERSION: "0.1.6"
+        MARKETING_VERSION: "0.2.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         DEVELOPMENT_LANGUAGE: en

--- a/scripts/release-mac.sh
+++ b/scripts/release-mac.sh
@@ -75,6 +75,9 @@ cat > "$ENTITLEMENTS_PATH" <<'PLIST'
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
+    <!-- The Longbridge OAuth flow answers the browser redirect on a loopback listener -->
+    <key>com.apple.security.network.server</key>
+    <true/>
     <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
     <array>
         <string>app.pulse.mac-spks</string>


### PR DESCRIPTION
## Summary

- **Longbridge as a real-time quote source** (FAT-832): speaks the OpenAPI binary WebSocket protocol directly (no SDK) — quotes, candles, intraday, and push subscriptions, including the US overnight session. Connect via browser OAuth (loopback redirect, PKCE, rotating refresh tokens) or manually pasted API keys; secrets live only in the Keychain.
- **Per-source refresh cadence** replaces the global refresh interval: each provider polls at its own configurable pace (Tencent 15s, Yahoo 60s, Longbridge 60s by default), only while its markets are open; push-capable sources stream instead.
- **Push-first UI**: watchlist and detail pages subscribe to live quotes while visible, with a coalescing buffer and NSMenu-tracking gate to keep the popover jank-free; the footer shows feed health instead of a refresh timestamp.
- **Provider pages redesigned**: every source is a navigation row with a detail page — enable switch, capability/freshness facts per market, poll cadence, and (for Longbridge) the account connection flow. The enable switch locks until an account is connected and truly stops data flow when turned off.
- Sort menu split into custom-order state and adjust-order action; provider detail pages match the settings page height.

## Test plan

- `swift test` in Packages/PulseCore: 60/60 green (protocol golden vectors from the official Go reference, signature vector, PKCE RFC 7636 vector, loopback server round-trips, overnight session mapping).
- Verified live end to end with a real Longbridge account: OAuth connect, HK/A-share/US quotes incl. overnight pushes, declared delays confirmed empirically (Tencent A-share realtime, Tencent HK exactly 15 min).
- Debug app exercised manually across enable/disable, connect/disconnect, and popover navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)