### PR TITLE
Release 0.3.0: sharing and unified intraday trends

### DIFF
--- a/Packages/PulseCore/Sources/PulseCore/Market/IntradayTrend.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Market/IntradayTrend.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// One exchange trading day expressed in trading minutes. Lunch breaks collapse to a
+/// single x-axis boundary so every surface can position intraday points identically.
+public struct IntradayTradingSession: Sendable, Hashable {
+    public let open: Date
+    public let morningEnd: Date?
+    public let afternoonStart: Date?
+    public let close: Date
+
+    public init(market: Market, referenceDate: Date) {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = market.timeZone
+        let day = calendar.startOfDay(for: referenceDate)
+        func at(_ hour: Int, _ minute: Int) -> Date {
+            calendar.date(bySettingHour: hour, minute: minute, second: 0, of: day) ?? day
+        }
+
+        switch market {
+        case .sh, .sz:
+            open = at(9, 30)
+            morningEnd = at(11, 30)
+            afternoonStart = at(13, 0)
+            close = at(15, 0)
+        case .hk:
+            open = at(9, 30)
+            morningEnd = at(12, 0)
+            afternoonStart = at(13, 0)
+            close = at(16, 0)
+        case .us:
+            open = at(9, 30)
+            morningEnd = nil
+            afternoonStart = nil
+            close = at(16, 0)
+        case .crypto:
+            open = at(0, 0)
+            morningEnd = nil
+            afternoonStart = nil
+            close = at(23, 59)
+        }
+    }
+
+    public var morningMinutes: Double {
+        (morningEnd ?? close).timeIntervalSince(open) / 60
+    }
+
+    public var totalMinutes: Double {
+        guard let afternoonStart else { return morningMinutes }
+        return morningMinutes + close.timeIntervalSince(afternoonStart) / 60
+    }
+
+    /// Includes a one-minute tolerance for providers that timestamp the opening/closing bucket edge.
+    public func contains(_ date: Date) -> Bool {
+        date >= open.addingTimeInterval(-60) && date <= close.addingTimeInterval(60)
+    }
+
+    /// Wall-clock date → trading-minute offset; lunch collapses onto the morning close.
+    public func minuteOffset(for date: Date) -> Double {
+        if date <= open { return 0 }
+        if let morningEnd, let afternoonStart {
+            if date <= morningEnd { return date.timeIntervalSince(open) / 60 }
+            if date < afternoonStart { return morningMinutes }
+            return min(morningMinutes + date.timeIntervalSince(afternoonStart) / 60, totalMinutes)
+        }
+        return min(date.timeIntervalSince(open) / 60, totalMinutes)
+    }
+
+    /// Trading-minute offset → wall-clock date, using the afternoon side of the lunch boundary.
+    public func date(forMinute minute: Double) -> Date {
+        if let afternoonStart, minute > morningMinutes {
+            return afternoonStart.addingTimeInterval((minute - morningMinutes) * 60)
+        }
+        return open.addingTimeInterval(minute * 60)
+    }
+}
+
+/// Canonical current-session series shared by the list, detail chart, and share cards.
+public struct IntradayTrendSnapshot: Sendable, Hashable {
+    public let session: IntradayTradingSession
+    public let candles: [Candle]
+
+    public init(candles: [Candle], market: Market) {
+        let referenceDate = candles.max(by: { $0.time < $1.time })?.time ?? .now
+        let session = IntradayTradingSession(market: market, referenceDate: referenceDate)
+        self.session = session
+        self.candles = candles
+            .filter { session.contains($0.time) }
+            .sorted { $0.time < $1.time }
+    }
+
+    public static func recommendedCandleCount(for market: Market) -> Int {
+        market == .crypto ? 24 * 60 : 400
+    }
+}

--- a/Packages/PulseCore/Sources/PulseCore/Store/MarketStore.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Store/MarketStore.swift
@@ -16,8 +16,8 @@ public struct CandleCacheKey: Hashable, Sendable {
 @Observable
 public final class MarketStore {
     public private(set) var quotes: [SymbolID: Quote] = [:]
-    /// Intraday close series used for the sparkline in list rows
-    public private(set) var sparklines: [SymbolID: [Double]] = [:]
+    /// Canonical current-session minute candles used by list rows and share cards.
+    public private(set) var sparklines: [SymbolID: [Candle]] = [:]
     public private(set) var lastRefresh: Date?
     public private(set) var lastError: String?
 
@@ -63,8 +63,8 @@ public final class MarketStore {
         return incoming.timestamp >= existing.timestamp
     }
 
-    public func apply(sparkline values: [Double], for symbol: SymbolID) {
-        sparklines[symbol] = values
+    public func apply(sparkline candles: [Candle], for symbol: SymbolID) {
+        sparklines[symbol] = candles
     }
 
     public func reportError(_ message: String) {

--- a/Packages/PulseCore/Sources/PulseCore/Store/RefreshEngine.swift
+++ b/Packages/PulseCore/Sources/PulseCore/Store/RefreshEngine.swift
@@ -139,8 +139,14 @@ public final class RefreshEngine {
 
             // Record the time regardless of success: symbols a source lacks (e.g. A-share indices missing from Yahoo) shouldn't be retried over and over
             lastSparklineAt[symbol] = .now
-            if let candles = try? await provider.candles(for: symbol, period: .minute5, count: 60) {
-                store.apply(sparkline: candles.map(\.close), for: symbol)
+            let count = IntradayTrendSnapshot.recommendedCandleCount(for: symbol.market)
+            if let candles = try? await provider.candles(for: symbol, period: .minute1, count: count) {
+                let trend = IntradayTrendSnapshot(candles: candles, market: symbol.market)
+                store.apply(sparkline: trend.candles, for: symbol)
+                store.cache(
+                    candles: trend.candles,
+                    for: CandleCacheKey(symbol: symbol, period: .minute1)
+                )
             }
             // Fetch one at a time with a gap in between to avoid a request burst against a single source (which would trigger rate limiting)
             fetched += 1
@@ -155,15 +161,28 @@ public final class RefreshEngine {
         let key = CandleCacheKey(symbol: symbol, period: period)
         let maxAge: TimeInterval = period.isIntraday ? 60 : 600
         if let cached = store.cachedCandles(for: key, maxAge: maxAge) {
-            return cached
+            return synchronizeIntradayTrend(cached, for: symbol, period: period)
         }
         do {
             let candles = try await provider.candles(for: symbol, period: period, count: count)
-            store.cache(candles: candles, for: key)
-            return candles
+            let synchronized = synchronizeIntradayTrend(candles, for: symbol, period: period)
+            store.cache(candles: synchronized, for: key)
+            return synchronized
         } catch {
             store.reportError(String(describing: error))
-            return store.cachedCandles(for: key, maxAge: .infinity) ?? []
+            let cached = store.cachedCandles(for: key, maxAge: .infinity) ?? []
+            return synchronizeIntradayTrend(cached, for: symbol, period: period)
         }
+    }
+
+    private func synchronizeIntradayTrend(
+        _ candles: [Candle],
+        for symbol: SymbolID,
+        period: CandlePeriod
+    ) -> [Candle] {
+        guard period == .minute1 else { return candles }
+        let trend = IntradayTrendSnapshot(candles: candles, market: symbol.market)
+        store.apply(sparkline: trend.candles, for: symbol)
+        return trend.candles
     }
 }

--- a/Packages/PulseCore/Tests/PulseCoreTests/IntradayTrendTests.swift
+++ b/Packages/PulseCore/Tests/PulseCoreTests/IntradayTrendTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import PulseCore
+
+@Suite("Canonical intraday trend")
+struct IntradayTrendTests {
+    @Test("Keeps only the latest exchange session and sorts it")
+    func latestSessionFiltering() throws {
+        let calendar = exchangeCalendar(.sh)
+        let latestDay = try #require(calendar.date(from: DateComponents(year: 2026, month: 7, day: 15)))
+        let priorDay = try #require(calendar.date(byAdding: .day, value: -1, to: latestDay))
+        let candles = [
+            candle(at: priorDay.addingTimeInterval(14 * 3600), close: 90),
+            candle(at: latestDay.addingTimeInterval(13 * 3600 + 5 * 60), close: 102),
+            candle(at: latestDay.addingTimeInterval(9 * 3600 + 31 * 60), close: 100),
+            candle(at: latestDay.addingTimeInterval(8 * 3600), close: 99),
+        ]
+
+        let trend = IntradayTrendSnapshot(candles: candles, market: .sh)
+
+        #expect(trend.candles.map(\.close) == [100, 102])
+        #expect(trend.session.minuteOffset(for: trend.candles[0].time) == 1)
+        #expect(trend.session.minuteOffset(for: trend.candles[1].time) == 125)
+        #expect(trend.session.totalMinutes == 240)
+    }
+
+    @Test("Uses one full day of minute data for every market")
+    func recommendedCounts() {
+        #expect(IntradayTrendSnapshot.recommendedCandleCount(for: .sh) == 400)
+        #expect(IntradayTrendSnapshot.recommendedCandleCount(for: .us) == 400)
+        #expect(IntradayTrendSnapshot.recommendedCandleCount(for: .crypto) == 1_440)
+    }
+
+    private func exchangeCalendar(_ market: Market) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = market.timeZone
+        return calendar
+    }
+
+    private func candle(at time: Date, close: Double) -> Candle {
+        Candle(time: time, open: close, high: close, low: close, close: close)
+    }
+}

--- a/Packages/PulseUI/Sources/PulseUI/IntradayChartView.swift
+++ b/Packages/PulseUI/Sources/PulseUI/IntradayChartView.swift
@@ -70,7 +70,7 @@ public struct IntradayChartView: View {
     }
 
     @ChartContentBuilder
-    private func marks(session: TradingSession) -> some ChartContent {
+    private func marks(session: IntradayTradingSession) -> some ChartContent {
         ForEach(lineSegments) { segment in
             ForEach(segment.candles, id: \.time) { candle in
                 LineMark(
@@ -98,26 +98,15 @@ public struct IntradayChartView: View {
     // MARK: - Trading-minute axis
 
     /// The session frame for the day being displayed (taken from the most recent candle).
-    private var session: TradingSession {
-        let day = marketCalendar.startOfDay(for: candles.max(by: { $0.time < $1.time })?.time ?? .now)
-        func at(_ hour: Int, _ minute: Int) -> Date {
-            marketCalendar.date(bySettingHour: hour, minute: minute, second: 0, of: day) ?? day
-        }
-        return switch market {
-        case .sh, .sz:
-            TradingSession(open: at(9, 30), morningEnd: at(11, 30), afternoonStart: at(13, 0), close: at(15, 0))
-        case .hk:
-            TradingSession(open: at(9, 30), morningEnd: at(12, 0), afternoonStart: at(13, 0), close: at(16, 0))
-        case .us:
-            TradingSession(open: at(9, 30), morningEnd: nil, afternoonStart: nil, close: at(16, 0))
-        case .crypto:
-            TradingSession(open: at(0, 0), morningEnd: nil, afternoonStart: nil, close: at(23, 59))
-        }
+    private var trend: IntradayTrendSnapshot {
+        IntradayTrendSnapshot(candles: candles, market: market)
     }
+
+    private var session: IntradayTradingSession { trend.session }
 
     /// Three wall-clock ticks, mainstream-app style (e.g. THS): open at the left edge, close at the
     /// right edge, and the lunch boundary (midday for the US) in between.
-    private func xTicks(session: TradingSession) -> [Double] {
+    private func xTicks(session: IntradayTradingSession) -> [Double] {
         switch market {
         case .sh, .sz, .hk: [0, session.morningMinutes, session.totalMinutes]
         case .us: [0, 150, session.totalMinutes]  // 150 trading minutes past 9:30 = 12:00
@@ -125,24 +114,19 @@ public struct IntradayChartView: View {
         }
     }
 
-    private func tickLabel(forMinute minute: Double, session: TradingSession) -> String {
+    private func tickLabel(forMinute minute: Double, session: IntradayTradingSession) -> String {
         axisTimeFormatter.string(from: session.date(forMinute: minute))
     }
 
     /// Edge labels anchor inward so they hug the plot borders instead of spilling outside.
-    private func tickAnchor(forMinute minute: Double, session: TradingSession) -> UnitPoint {
+    private func tickAnchor(forMinute minute: Double, session: IntradayTradingSession) -> UnitPoint {
         if minute < 0.5 { return .topLeading }
         if minute > session.totalMinutes - 0.5 { return .topTrailing }
         return .top
     }
 
     /// Candles inside the displayed session (drops the opening auction and any pre/post-market strays).
-    private var sessionCandles: [Candle] {
-        let session = self.session
-        return candles
-            .filter { $0.time >= session.open.addingTimeInterval(-60) && $0.time <= session.close.addingTimeInterval(60) }
-            .sorted { $0.time < $1.time }
-    }
+    private var sessionCandles: [Candle] { trend.candles }
 
     // MARK: - Crosshair
 
@@ -179,7 +163,7 @@ public struct IntradayChartView: View {
     }
 
     /// Snap to the candle closest to the cursor's trading-minute position.
-    private func candle(at point: CGPoint, proxy: ChartProxy, plot: CGRect, session: TradingSession) -> Candle? {
+    private func candle(at point: CGPoint, proxy: ChartProxy, plot: CGRect, session: IntradayTradingSession) -> Candle? {
         guard plot.insetBy(dx: -2, dy: -2).contains(point),
               let minute: Double = proxy.value(atX: point.x - plot.origin.x) else { return nil }
         return sessionCandles.min {
@@ -237,53 +221,11 @@ public struct IntradayChartView: View {
         market.isChinaA || market == .hk ? 30 * 60 : 20 * 60
     }
 
-    private var marketCalendar: Calendar {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = market.timeZone
-        return calendar
-    }
-
     private var axisTimeFormatter: DateFormatter {
         let formatter = DateFormatter()
         formatter.dateFormat = "H:mm"
         formatter.timeZone = market.timeZone
         return formatter
-    }
-}
-
-/// One trading day's session frame, measured in "trading minutes" that skip the lunch break.
-private struct TradingSession {
-    let open: Date
-    let morningEnd: Date?
-    let afternoonStart: Date?
-    let close: Date
-
-    var morningMinutes: Double {
-        (morningEnd ?? close).timeIntervalSince(open) / 60
-    }
-
-    var totalMinutes: Double {
-        guard let afternoonStart else { return morningMinutes }
-        return morningMinutes + close.timeIntervalSince(afternoonStart) / 60
-    }
-
-    /// Wall-clock date → trading-minute offset; lunch collapses onto the morning close, out-of-session clamps to the edges.
-    func minuteOffset(for date: Date) -> Double {
-        if date <= open { return 0 }
-        if let morningEnd, let afternoonStart {
-            if date <= morningEnd { return date.timeIntervalSince(open) / 60 }
-            if date < afternoonStart { return morningMinutes }
-            return min(morningMinutes + date.timeIntervalSince(afternoonStart) / 60, totalMinutes)
-        }
-        return min(date.timeIntervalSince(open) / 60, totalMinutes)
-    }
-
-    /// Trading-minute offset → wall-clock date (inverse of `minuteOffset`, afternoon side of the boundary).
-    func date(forMinute minute: Double) -> Date {
-        if let afternoonStart, minute > morningMinutes {
-            return afternoonStart.addingTimeInterval((minute - morningMinutes) * 60)
-        }
-        return open.addingTimeInterval(minute * 60)
     }
 }
 

--- a/Packages/PulseUI/Sources/PulseUI/IntradaySparklineView.swift
+++ b/Packages/PulseUI/Sources/PulseUI/IntradaySparklineView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+import PulseCore
+
+/// Lightweight Canvas rendering of the same canonical trading-session geometry used by
+/// `IntradayChartView`. It is suitable for dense list rows and off-screen share images.
+public struct IntradaySparklineView: View {
+    let candles: [Candle]
+    let previousClose: Double?
+    let market: Market
+    let tint: Color
+
+    public init(candles: [Candle], previousClose: Double? = nil, market: Market, tint: Color) {
+        self.candles = candles
+        self.previousClose = previousClose
+        self.market = market
+        self.tint = tint
+    }
+
+    public var body: some View {
+        let trend = IntradayTrendSnapshot(candles: candles, market: market)
+        Canvas { context, size in
+            guard trend.candles.count > 1 else { return }
+            let domain = yDomain(for: trend.candles)
+
+            func point(for candle: Candle) -> CGPoint {
+                let x = trend.session.minuteOffset(for: candle.time) / trend.session.totalMinutes
+                let y = 1 - (candle.close - domain.lowerBound) / (domain.upperBound - domain.lowerBound)
+                return CGPoint(x: size.width * CGFloat(x), y: size.height * CGFloat(y))
+            }
+
+            for segment in lineSegments(trend.candles) {
+                var line = Path()
+                line.move(to: point(for: segment[0]))
+                for candle in segment.dropFirst() {
+                    line.addLine(to: point(for: candle))
+                }
+
+                var area = line
+                area.addLine(to: CGPoint(x: point(for: segment.last!).x, y: size.height))
+                area.addLine(to: CGPoint(x: point(for: segment[0]).x, y: size.height))
+                area.closeSubpath()
+                context.fill(area, with: .linearGradient(
+                    Gradient(colors: [tint.opacity(0.16), tint.opacity(0.01)]),
+                    startPoint: .zero,
+                    endPoint: CGPoint(x: 0, y: size.height)
+                ))
+                context.stroke(
+                    line,
+                    with: .color(tint),
+                    style: StrokeStyle(lineWidth: 1.2, lineCap: .round, lineJoin: .round)
+                )
+            }
+
+            if let previousClose {
+                let normalizedY = 1 - (previousClose - domain.lowerBound) / (domain.upperBound - domain.lowerBound)
+                let y = size.height * CGFloat(normalizedY)
+                var rule = Path()
+                rule.move(to: CGPoint(x: 0, y: y))
+                rule.addLine(to: CGPoint(x: size.width, y: y))
+                context.stroke(
+                    rule,
+                    with: .color(.secondary.opacity(0.35)),
+                    style: StrokeStyle(lineWidth: 0.5, dash: [2, 2])
+                )
+            }
+        }
+    }
+
+    private func yDomain(for candles: [Candle]) -> ClosedRange<Double> {
+        let closes = candles.map(\.close)
+        let baseline = previousClose ?? closes.first ?? 0
+        var lo = min(closes.min() ?? baseline, baseline)
+        var hi = max(closes.max() ?? baseline, baseline)
+        let pad = max((hi - lo) * 0.1, hi * 0.001, 0.0001)
+        lo -= pad
+        hi += pad
+        return lo...hi
+    }
+
+    private func lineSegments(_ candles: [Candle]) -> [[Candle]] {
+        guard let first = candles.first else { return [] }
+        let breakInterval: TimeInterval = market.isChinaA || market == .hk ? 30 * 60 : 20 * 60
+        var segments: [[Candle]] = []
+        var current = [first]
+        for candle in candles.dropFirst() {
+            if let previous = current.last,
+               candle.time.timeIntervalSince(previous.time) > breakInterval {
+                segments.append(current)
+                current = [candle]
+            } else {
+                current.append(candle)
+            }
+        }
+        segments.append(current)
+        return segments
+    }
+}

--- a/PulseMac/Sources/AppState.swift
+++ b/PulseMac/Sources/AppState.swift
@@ -35,7 +35,12 @@ final class AppState {
         let settings = AppSettings()
         let watchlist = WatchlistStore()
         let market = MarketStore()
-        let (auth, authState) = Self.loadLongbridgeAuth()
+        // Image-rendering self-tests do not need live credentials. Skipping Keychain access
+        // also keeps the headless test from waiting on an authorization prompt.
+        let authContext: (LongbridgeAuth?, LongbridgeAuthState) = CommandLine.arguments.contains("--share-selftest")
+            ? (nil, .none)
+            : Self.loadLongbridgeAuth()
+        let (auth, authState) = authContext
         let longbridge = LongbridgeProvider(auth: auth)
         var disabledIDs = settings.disabledProviderIDs
         if authState == .none { disabledIDs.insert(LongbridgeProvider.providerID) }
@@ -53,6 +58,9 @@ final class AppState {
         )
         self.engine = RefreshEngine(provider: provider, store: market, watchlist: watchlist,
                                     pollOverrides: settings.providerPollIntervals)
+        self.liveStreaming = authState != .none
+            && !disabledIDs.contains(LongbridgeProvider.providerID)
+            && watchlist.symbols.contains { longbridge.descriptor.supports(.streaming, in: $0.market) }
         engine.start()
         startRotation()
         observeMenuTracking()
@@ -110,7 +118,7 @@ final class AppState {
             // A push subscription checks availability only when it starts, so an
             // already-running stream would keep delivering from a source the user
             // just turned off — resubscribe against the new availability.
-            if watchlistStreamTask != nil { restartWatchlistStream() }
+            if isPopoverVisible { restartWatchlistStream() }
         }
     }
 
@@ -230,6 +238,8 @@ final class AppState {
     // MARK: - Live watchlist (push-first home page)
 
     @ObservationIgnored private var watchlistStreamTask: Task<Void, Never>?
+    @ObservationIgnored private var watchlistStreamSessionID: UUID?
+    @ObservationIgnored private var isPopoverVisible = false
     @ObservationIgnored private var pendingPushes: [SymbolID: Quote] = [:]
     @ObservationIgnored private var pushFlushTask: Task<Void, Never>?
 
@@ -237,39 +247,57 @@ final class AppState {
     /// ticks live; the rest keep their source's poll cadence. Closing the popover
     /// unsubscribes — the menu bar text is fine at poll granularity.
     func setPopoverVisible(_ visible: Bool) {
+        isPopoverVisible = visible
         watchlistStreamTask?.cancel()
         watchlistStreamTask = nil
+        watchlistStreamSessionID = nil
+        // Keep the last known/expected streaming state while the popover disappears.
+        // Resetting it here makes the still-visible closing frame flash "quotes healthy".
         guard visible else { return }
         restartWatchlistStream()
     }
 
     /// Re-subscribes after watchlist edits while the popover is open.
     func watchlistSymbolsChanged() {
-        guard watchlistStreamTask != nil else { return }
+        guard isPopoverVisible else { return }
         restartWatchlistStream()
     }
 
-    /// True once the live stream has actually delivered a tick — proof of life, not just
-    /// "a subscription was attempted". Drives the footer's "streaming" status.
+    /// True while a configured live source is being connected or actively delivering.
+    /// Deliberate popover lifecycle cancellations keep this stable to avoid status flicker;
+    /// unsupported configuration and unexpected stream termination reset it.
     private(set) var liveStreaming = false
 
     private func restartWatchlistStream() {
         watchlistStreamTask?.cancel()
-        liveStreaming = false
+        watchlistStreamTask = nil
+        watchlistStreamSessionID = nil
         let symbols = watchlist.symbols
-        guard !symbols.isEmpty, let stream = provider.quoteStream(for: symbols) else {
-            watchlistStreamTask = nil
+        guard longbridgeConfigured,
+              isProviderEnabled(LongbridgeProvider.providerID),
+              symbols.contains(where: { longbridge.descriptor.supports(.streaming, in: $0.market) }),
+              let stream = provider.quoteStream(for: symbols) else {
+            liveStreaming = false
             return
         }
+        liveStreaming = true
+        let sessionID = UUID()
+        watchlistStreamSessionID = sessionID
         watchlistStreamTask = Task { [weak self] in
-            defer { self?.liveStreaming = false }
             do {
                 for try await quote in stream {
+                    guard self?.watchlistStreamSessionID == sessionID else { return }
                     self?.liveStreaming = true
                     self?.ingestStreamedQuote(quote)
                 }
             } catch {
                 // Stream dropped (socket reconnect etc.); polling still covers the list.
+            }
+            guard let self, self.watchlistStreamSessionID == sessionID else { return }
+            self.watchlistStreamTask = nil
+            self.watchlistStreamSessionID = nil
+            if !Task.isCancelled {
+                self.liveStreaming = false
             }
         }
     }

--- a/PulseMac/Sources/DetailView.swift
+++ b/PulseMac/Sources/DetailView.swift
@@ -4,6 +4,7 @@ import PulseUI
 
 struct DetailView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let symbol: SymbolID
     @Binding var route: PopoverRoute
@@ -12,6 +13,7 @@ struct DetailView: View {
     @State private var candles: [Candle] = []
     @State private var isLoading = false
     @State private var isFirstLoad = true
+    @State private var shareFeedback: ShareFeedback?
 
     private static let periods: [CandlePeriod] = [.minute1, .day, .week, .month]
 
@@ -115,6 +117,14 @@ struct DetailView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             Spacer()
+            ClusterIcon(
+                systemName: "square.and.arrow.up",
+                help: PulseLocalization.localizedString("action.copyShareSnapshot")
+            ) {
+                copyShareSnapshot()
+            }
+            .disabled(quote == nil || candles.isEmpty)
+            .opacity(quote == nil || candles.isEmpty ? 0.45 : 1)
             if let item {
                 ClusterIcon(
                     systemName: item.hasPosition ? "briefcase.fill" : "briefcase",
@@ -126,8 +136,60 @@ struct DetailView: View {
                 }
             }
         }
+        .overlay(alignment: .trailing) {
+            if let shareFeedback {
+                ShareFeedbackHUD(feedback: shareFeedback)
+                    .padding(.trailing, item == nil ? 30 : 58)
+                    .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .trailing)))
+                    .allowsHitTesting(false)
+            }
+        }
         .padding(.horizontal, 12)
         .padding(.vertical, 7)
+    }
+
+    @MainActor
+    private func copyShareSnapshot() {
+        do {
+            let snapshot = DetailShareSnapshot(
+                appState: appState,
+                symbol: symbol,
+                period: period,
+                candles: candles
+            )
+            let card = PulseShareCard(
+                metadata: PulseShareCardMetadata(updatedAtText: snapshot.updatedAtText)
+            ) {
+                DetailShareContent(snapshot: snapshot)
+            }
+            let artifact = try ShareImageRenderer.render(
+                card,
+                configuration: .socialPortrait(
+                    height: snapshot.preferredImageHeight,
+                    colorScheme: colorScheme,
+                    locale: appState.settings.locale
+                )
+            )
+            try ClipboardImageExporter.write(artifact)
+            showShareFeedback(isSuccess: true)
+        } catch {
+            showShareFeedback(isSuccess: false)
+        }
+    }
+
+    @MainActor
+    private func showShareFeedback(isSuccess: Bool) {
+        let feedback = ShareFeedback(isSuccess: isSuccess)
+        withAnimation(.snappy(duration: 0.2)) {
+            shareFeedback = feedback
+        }
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(isSuccess ? 1.5 : 3))
+            guard shareFeedback?.id == feedback.id else { return }
+            withAnimation(.snappy(duration: 0.2)) {
+                shareFeedback = nil
+            }
+        }
     }
 
     // MARK: - Hero

--- a/PulseMac/Sources/SelfTest.swift
+++ b/PulseMac/Sources/SelfTest.swift
@@ -118,6 +118,29 @@ enum SelfTest {
                 throw ShareImageError.renderingFailed
             }
 
+            func trendCandles(_ values: [Double], market: Market) -> [Candle] {
+                var calendar = Calendar(identifier: .gregorian)
+                calendar.timeZone = market.timeZone
+                let day = calendar.date(from: DateComponents(year: 2026, month: 7, day: 15)) ?? .now
+                let startHour = market == .crypto ? 0 : 9
+                let startMinute = market == .crypto ? 0 : 30
+                let start = calendar.date(
+                    bySettingHour: startHour,
+                    minute: startMinute,
+                    second: 0,
+                    of: day
+                ) ?? day
+                return values.enumerated().map { index, close in
+                    Candle(
+                        time: start.addingTimeInterval(Double(index) * 60),
+                        open: close,
+                        high: close,
+                        low: close,
+                        close: close
+                    )
+                }
+            }
+
             let snapshot = WatchlistShareSnapshot(
                 rows: [
                     .init(
@@ -131,7 +154,7 @@ enum SelfTest {
                         change: 2.92,
                         previousClose: 228.50,
                         sessionLabel: nil,
-                        sparkline: [228.5, 229.2, 228.9, 230.4, 231.0, 231.42]
+                        sparkline: trendCandles([228.5, 229.2, 228.9, 230.4, 231.0, 231.42], market: .us)
                     ),
                     .init(
                         id: SymbolID(market: .hk, code: "700"),
@@ -144,7 +167,7 @@ enum SelfTest {
                         change: 4.50,
                         previousClose: 538.00,
                         sessionLabel: nil,
-                        sparkline: [538, 539, 537.8, 540.2, 541.6, 542.5]
+                        sparkline: trendCandles([538, 539, 537.8, 540.2, 541.6, 542.5], market: .hk)
                     ),
                     .init(
                         id: SymbolID(market: .sh, code: "600519"),
@@ -157,7 +180,7 @@ enum SelfTest {
                         change: -5.40,
                         previousClose: 1487.70,
                         sessionLabel: nil,
-                        sparkline: [1487.7, 1485.2, 1486.4, 1483.8, 1484.5, 1482.3]
+                        sparkline: trendCandles([1487.7, 1485.2, 1486.4, 1483.8, 1484.5, 1482.3], market: .sh)
                     ),
                     .init(
                         id: SymbolID(market: .us, code: "MSFT"),
@@ -170,7 +193,7 @@ enum SelfTest {
                         change: 2.34,
                         previousClose: 495.38,
                         sessionLabel: nil,
-                        sparkline: [495.4, 496.1, 495.8, 496.9, 497.1, 497.72]
+                        sparkline: trendCandles([495.4, 496.1, 495.8, 496.9, 497.1, 497.72], market: .us)
                     ),
                     .init(
                         id: SymbolID(market: .us, code: "NVDA"),
@@ -183,7 +206,7 @@ enum SelfTest {
                         change: -1.03,
                         previousClose: 165.95,
                         sessionLabel: nil,
-                        sparkline: [165.9, 165.5, 165.8, 165.1, 164.7, 164.92]
+                        sparkline: trendCandles([165.9, 165.5, 165.8, 165.1, 164.7, 164.92], market: .us)
                     ),
                     .init(
                         id: SymbolID(market: .hk, code: "9988"),
@@ -196,7 +219,7 @@ enum SelfTest {
                         change: 1.60,
                         previousClose: 110.20,
                         sessionLabel: nil,
-                        sparkline: [110.2, 110.6, 110.4, 111.0, 111.5, 111.8]
+                        sparkline: trendCandles([110.2, 110.6, 110.4, 111.0, 111.5, 111.8], market: .hk)
                     ),
                     .init(
                         id: SymbolID(market: .crypto, code: "BTC-USD"),
@@ -209,7 +232,7 @@ enum SelfTest {
                         change: 2460,
                         previousClose: 113960,
                         sessionLabel: nil,
-                        sparkline: [113960, 114800, 114300, 115400, 116000, 116420]
+                        sparkline: trendCandles([113960, 114800, 114300, 115400, 116000, 116420], market: .crypto)
                     ),
                 ],
                 redUp: true,
@@ -267,16 +290,66 @@ enum SelfTest {
                 throw ShareImageError.renderingFailed
             }
 
+            let detailQuote = Quote(
+                symbol: metricTestItem.symbol,
+                name: "Apple",
+                price: 231.42,
+                previousClose: 228.50,
+                open: 229.10,
+                high: 232.18,
+                low: 227.82,
+                volume: 48_260_000,
+                currencyCode: "USD",
+                marketState: .regular
+            )
+            let detailValues = (0..<120).map { index in
+                let minute = Double(index)
+                return 228.5 + minute * 0.024 + sin(minute / 8) * 0.72 + sin(minute / 2.7) * 0.18
+            }
+            let detailCandles = trendCandles(detailValues, market: .us)
+            let detailSnapshot = DetailShareSnapshot(
+                symbol: metricTestItem.symbol,
+                name: "Apple",
+                quote: detailQuote,
+                period: .minute1,
+                candles: detailCandles,
+                redUp: true,
+                updatedAtText: PulseLocalization.localizedString("refresh.updatedAt", "09:45")
+            )
+            let detailCard = PulseShareCard(
+                metadata: PulseShareCardMetadata(updatedAtText: detailSnapshot.updatedAtText)
+            ) {
+                DetailShareContent(snapshot: detailSnapshot)
+            }
+            let detailArtifact = try ShareImageRenderer.render(
+                detailCard,
+                configuration: .socialPortrait(
+                    height: detailSnapshot.preferredImageHeight,
+                    colorScheme: .light,
+                    locale: Locale(identifier: "en")
+                )
+            )
+            guard let detailBitmap = NSBitmapImageRep(data: detailArtifact.pngData),
+                  detailBitmap.pixelsWide == 1080,
+                  detailBitmap.pixelsHigh == 1024 else {
+                throw ShareImageError.renderingFailed
+            }
+
             let outputURL = URL(fileURLWithPath: NSTemporaryDirectory())
                 .appendingPathComponent("pulse-share-selftest.png")
             try artifact.pngData.write(to: outputURL, options: .atomic)
             let shortOutputURL = URL(fileURLWithPath: NSTemporaryDirectory())
                 .appendingPathComponent("pulse-share-selftest-short.png")
             try shortArtifact.pngData.write(to: shortOutputURL, options: .atomic)
+            let detailOutputURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("pulse-detail-share-selftest.png")
+            try detailArtifact.pngData.write(to: detailOutputURL, options: .atomic)
             print(
                 "SHARE_SELFTEST: ✅ PNG/TIFF copied to isolated pasteboard, "
                     + "images=\(shortBitmap.pixelsWide)x\(shortBitmap.pixelsHigh)..."
-                    + "\(bitmap.pixelsWide)x\(bitmap.pixelsHigh), outputs=\(shortOutputURL.path),\(outputURL.path)"
+                    + "\(bitmap.pixelsWide)x\(bitmap.pixelsHigh), detail="
+                    + "\(detailBitmap.pixelsWide)x\(detailBitmap.pixelsHigh), outputs="
+                    + "\(shortOutputURL.path),\(outputURL.path),\(detailOutputURL.path)"
             )
             return true
         } catch {

--- a/PulseMac/Sources/Sharing/DetailShareSnapshot.swift
+++ b/PulseMac/Sources/Sharing/DetailShareSnapshot.swift
@@ -1,0 +1,230 @@
+import SwiftUI
+import PulseCore
+import PulseUI
+
+struct DetailShareSnapshot {
+    struct Stat: Identifiable {
+        let id: String
+        let label: String
+        let value: String
+    }
+
+    let symbol: SymbolID
+    let name: String
+    let priceLabel: String
+    let priceText: String
+    let currencyCode: String?
+    let changeText: String
+    let changePercentText: String
+    let changeValue: Double?
+    let previousClose: Double?
+    let period: CandlePeriod
+    let periodName: String
+    let trendCandles: [Candle]
+    let stats: [Stat]
+    let redUp: Bool
+    let updatedAtText: String
+
+    let preferredImageHeight: CGFloat = 512
+
+    init(
+        symbol: SymbolID,
+        name: String,
+        quote: Quote?,
+        period: CandlePeriod,
+        candles: [Candle],
+        redUp: Bool,
+        updatedAtText: String
+    ) {
+        self.symbol = symbol
+        self.name = name
+        priceLabel = quote.map(Self.priceLabel) ?? PulseLocalization.localizedString("quote.price.current")
+        priceText = quote.map { PriceFormatter.price($0.price) } ?? "—"
+        currencyCode = quote?.currencyCode ?? symbol.market.currencyCode
+        changeText = quote.map { PriceFormatter.change($0.change) } ?? "—"
+        changePercentText = quote.map { PriceFormatter.percent($0.changePercent) } ?? "—"
+        changeValue = quote?.change
+        previousClose = quote?.previousClose
+        self.period = period
+        periodName = period.displayName
+        trendCandles = period.isIntraday
+            ? IntradayTrendSnapshot(candles: candles, market: symbol.market).candles
+            : candles.sorted { $0.time < $1.time }
+        stats = [
+            Stat(
+                id: "open",
+                label: PulseLocalization.localizedString("stat.open"),
+                value: quote?.open.map(PriceFormatter.price) ?? "—"
+            ),
+            Stat(
+                id: "high",
+                label: PulseLocalization.localizedString("stat.high"),
+                value: quote?.high.map(PriceFormatter.price) ?? "—"
+            ),
+            Stat(
+                id: "low",
+                label: PulseLocalization.localizedString("stat.low"),
+                value: quote?.low.map(PriceFormatter.price) ?? "—"
+            ),
+            Stat(
+                id: "previousClose",
+                label: PulseLocalization.localizedString("stat.previousClose"),
+                value: quote.map { PriceFormatter.price($0.previousClose) } ?? "—"
+            ),
+            Stat(
+                id: "volume",
+                label: PulseLocalization.localizedString("stat.volume"),
+                value: quote?.volume.map(PriceFormatter.compact) ?? "—"
+            ),
+            Stat(
+                id: "amplitude",
+                label: PulseLocalization.localizedString("stat.amplitude"),
+                value: quote?.amplitudePercent.map(PriceFormatter.percentMagnitude) ?? "—"
+            ),
+        ]
+        self.redUp = redUp
+        self.updatedAtText = updatedAtText
+    }
+
+    @MainActor
+    init(appState: AppState, symbol: SymbolID, period: CandlePeriod, candles: [Candle]) {
+        let quote = appState.market.quote(for: symbol)
+        self.init(
+            symbol: symbol,
+            name: quote?.name ?? appState.watchlist.item(for: symbol)?.displayName ?? symbol.code,
+            quote: quote,
+            period: period,
+            candles: candles,
+            redUp: appState.settings.redUp,
+            updatedAtText: PulseLocalization.localizedString(
+                "refresh.updatedAt",
+                Date.now.formatted(date: .omitted, time: .standard)
+            )
+        )
+    }
+
+    private static func priceLabel(for quote: Quote) -> String {
+        switch quote.marketState {
+        case .preMarket:
+            PulseLocalization.localizedString("quote.price.preMarket")
+        case .postMarket:
+            PulseLocalization.localizedString("quote.price.postMarket")
+        case .overnight:
+            PulseLocalization.localizedString("quote.price.overnight")
+        case .closed:
+            PulseLocalization.localizedString("quote.price.close")
+        case .regular, .none:
+            PulseLocalization.localizedString("quote.price.current")
+        }
+    }
+}
+
+struct DetailShareContent: View {
+    let snapshot: DetailShareSnapshot
+
+    private var palette: ChangePalette { ChangePalette(redUp: snapshot.redUp) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            identity
+            quoteHero
+            trend
+            stats
+        }
+    }
+
+    private var identity: some View {
+        HStack(spacing: 8) {
+            Text(snapshot.name)
+                .font(.system(size: 21, weight: .bold))
+                .lineLimit(1)
+            MarketBadge(market: snapshot.symbol.market)
+            Text(snapshot.symbol.code)
+                .font(.system(size: 12).monospaced())
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var quoteHero: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(snapshot.priceLabel)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.tertiary)
+            HStack(alignment: .firstTextBaseline, spacing: 7) {
+                Text(snapshot.priceText)
+                    .font(.system(size: 38, weight: .semibold).monospacedDigit())
+                if let currencyCode = snapshot.currencyCode {
+                    Text(currencyCode)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                Spacer(minLength: 12)
+                HStack(alignment: .firstTextBaseline, spacing: 7) {
+                    Text(snapshot.changeText)
+                    Text(snapshot.changePercentText)
+                        .fontWeight(.semibold)
+                }
+                .font(.system(size: 16).monospacedDigit())
+            }
+            .foregroundStyle(snapshot.changeValue.map(palette.color(for:)) ?? .secondary)
+        }
+    }
+
+    private var trend: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(PulseLocalization.localizedString("detail.section.trend"))
+                    .font(.system(size: 12, weight: .semibold))
+                Spacer()
+                Text(snapshot.periodName)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+
+            if snapshot.trendCandles.isEmpty {
+                Text(PulseLocalization.localizedString("share.updateUnavailable"))
+                    .font(.system(size: 12))
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity, minHeight: 82)
+            } else if snapshot.period.isIntraday {
+                IntradaySparklineView(
+                    candles: snapshot.trendCandles,
+                    previousClose: snapshot.previousClose,
+                    market: snapshot.symbol.market,
+                    tint: snapshot.changeValue.map(palette.color(for:)) ?? .secondary
+                )
+                .frame(maxWidth: .infinity, minHeight: 82, maxHeight: 82)
+            } else {
+                SparklineView(
+                    values: snapshot.trendCandles.map(\.close),
+                    baseline: snapshot.previousClose,
+                    tint: snapshot.changeValue.map(palette.color(for:)) ?? .secondary
+                )
+                .frame(maxWidth: .infinity, minHeight: 82, maxHeight: 82)
+            }
+        }
+        .padding(14)
+        .background(.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private var stats: some View {
+        Grid(horizontalSpacing: 20, verticalSpacing: 12) {
+            ForEach(0..<2, id: \.self) { row in
+                GridRow {
+                    ForEach(Array(snapshot.stats[(row * 3)..<(row * 3 + 3)])) { stat in
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(stat.label)
+                                .font(.system(size: 10.5))
+                                .foregroundStyle(.tertiary)
+                            Text(stat.value)
+                                .font(.system(size: 13, weight: .medium).monospacedDigit())
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PulseMac/Sources/Sharing/PulseShareCard.swift
+++ b/PulseMac/Sources/Sharing/PulseShareCard.swift
@@ -80,7 +80,7 @@ struct PulseShareCard<Content: View>: View {
         .foregroundStyle(.secondary)
         .padding(.horizontal, 24)
         .padding(.top, 14)
-        .padding(.bottom, 18)
+        .padding(.bottom, 24)
     }
 
     private var background: Color {

--- a/PulseMac/Sources/Sharing/ShareFeedback.swift
+++ b/PulseMac/Sources/Sharing/ShareFeedback.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import PulseCore
+
+struct ShareFeedback: Equatable {
+    let id = UUID()
+    let isSuccess: Bool
+}
+
+/// Shared transient confirmation for every copy-to-clipboard share action.
+struct ShareFeedbackHUD: View {
+    let feedback: ShareFeedback
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: feedback.isSuccess ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(feedback.isSuccess ? .green : .orange)
+            Text(PulseLocalization.localizedString(
+                feedback.isSuccess ? "share.copySuccess" : "share.copyFailed"
+            ))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+        }
+        .font(.system(size: 10.5, weight: .medium))
+        .padding(.horizontal, 8)
+        .frame(height: 22)
+        .fixedSize(horizontal: true, vertical: false)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(.separator.opacity(0.35), lineWidth: 0.5)
+        }
+        .accessibilityLabel(PulseLocalization.localizedString(
+            feedback.isSuccess ? "share.copySuccess" : "share.copyFailed"
+        ))
+    }
+}

--- a/PulseMac/Sources/Sharing/WatchlistShareSnapshot.swift
+++ b/PulseMac/Sources/Sharing/WatchlistShareSnapshot.swift
@@ -14,7 +14,7 @@ struct WatchlistShareSnapshot {
         let change: Double?
         let previousClose: Double?
         let sessionLabel: String?
-        let sparkline: [Double]
+        let sparkline: [Candle]
     }
 
     let rows: [Row]
@@ -159,9 +159,10 @@ private struct WatchlistShareRow: View {
                 }
                 .frame(width: titleColumnWidth, alignment: .leading)
 
-                SparklineView(
-                    values: row.sparkline,
-                    baseline: row.previousClose,
+                IntradaySparklineView(
+                    candles: row.sparkline,
+                    previousClose: row.previousClose,
+                    market: row.market,
                     tint: row.change.map(palette.color(for:)) ?? .secondary
                 )
                 .frame(maxWidth: .infinity, minHeight: 34, maxHeight: 34)

--- a/PulseMac/Sources/WatchlistView.swift
+++ b/PulseMac/Sources/WatchlistView.swift
@@ -80,17 +80,15 @@ struct WatchlistView: View {
                 Text(Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "Pulse")
                     .font(.system(size: 12.5, weight: .semibold))
                 Spacer()
+                ClusterIcon(
+                    systemName: "square.and.arrow.up",
+                    help: PulseLocalization.localizedString("action.copyShareSnapshot")
+                ) {
+                    copyShareSnapshot()
+                }
+                .disabled(appState.watchlist.isEmpty)
+                .opacity(appState.watchlist.isEmpty ? 0.45 : 1)
                 ClusterMenu(systemName: "ellipsis.circle", help: PulseLocalization.localizedString("action.more")) {
-                    Button {
-                        copyShareSnapshot()
-                    } label: {
-                        Label(
-                            PulseLocalization.localizedString("action.copyShareSnapshot"),
-                            systemImage: "doc.on.doc"
-                        )
-                    }
-                    .disabled(appState.watchlist.isEmpty)
-                    Divider()
                     Menu {
                         ForEach(WatchRowMetricMode.allCases, id: \.self) { mode in
                             Toggle(mode.displayName, isOn: metricModeBinding(mode))
@@ -143,8 +141,8 @@ struct WatchlistView: View {
             }
             .overlay(alignment: .trailing) {
                 if let shareFeedback {
-                    shareFeedbackHUD(shareFeedback)
-                        .padding(.trailing, 34)
+                    ShareFeedbackHUD(feedback: shareFeedback)
+                        .padding(.trailing, 62)
                         .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .trailing)))
                         .allowsHitTesting(false)
                 }
@@ -232,30 +230,6 @@ struct WatchlistView: View {
         .frame(height: 22)
         .padding(.leading, 12)
         .padding(.bottom, 4)
-    }
-
-    private func shareFeedbackHUD(_ feedback: ShareFeedback) -> some View {
-        HStack(spacing: 5) {
-            Image(systemName: feedback.isSuccess ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                .foregroundStyle(feedback.isSuccess ? .green : .orange)
-            Text(PulseLocalization.localizedString(
-                feedback.isSuccess ? "share.copySuccess" : "share.copyFailed"
-            ))
-                .foregroundStyle(.primary)
-                .lineLimit(1)
-        }
-        .font(.system(size: 10.5, weight: .medium))
-        .padding(.horizontal, 8)
-        .frame(height: 22)
-        .fixedSize(horizontal: true, vertical: false)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .stroke(.separator.opacity(0.35), lineWidth: 0.5)
-        }
-        .accessibilityLabel(PulseLocalization.localizedString(
-            feedback.isSuccess ? "share.copySuccess" : "share.copyFailed"
-        ))
     }
 
     @MainActor
@@ -604,11 +578,6 @@ struct WatchlistView: View {
     }
 }
 
-private struct ShareFeedback: Equatable {
-    let id = UUID()
-    let isSuccess: Bool
-}
-
 // MARK: - Components
 
 private enum WatchlistOrderMode: String {
@@ -823,9 +792,10 @@ struct WatchRow: View {
                 }
                 .frame(width: titleColumnWidth, alignment: .leading)
 
-                SparklineView(
-                    values: appState.market.sparklines[item.symbol] ?? [],
-                    baseline: quote?.previousClose,
+                IntradaySparklineView(
+                    candles: appState.market.sparklines[item.symbol] ?? [],
+                    previousClose: quote?.previousClose,
+                    market: item.symbol.market,
                     tint: color
                 )
                 .frame(maxWidth: .infinity, minHeight: 30, maxHeight: 30)

--- a/project.yml
+++ b/project.yml
@@ -59,7 +59,7 @@ targets:
           - $(PRODUCT_BUNDLE_IDENTIFIER)-spki
     settings:
       base:
-        MARKETING_VERSION: "0.2.0"
+        MARKETING_VERSION: "0.3.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_VERSION: "6.0"
         DEVELOPMENT_LANGUAGE: en

--- a/release-notes/0.3.0.md
+++ b/release-notes/0.3.0.md
@@ -1,0 +1,11 @@
+Pulse 0.3.0
+
+What's new:
+- Share a symbol directly from its detail page. The clipboard-ready image includes the public quote, intraday trend, and market statistics while keeping portfolio holdings private.
+- The watchlist share action now has its own top-level button, so sharing no longer requires opening the overflow menu.
+- Watchlist rows, detail pages, and shared images now use the same current-session one-minute trend data, trading-time axis, previous-close baseline, lunch-break handling, and gap detection.
+- Trend data is shared between the watchlist and detail cache, keeping the three surfaces on the same market snapshot whenever possible.
+- Live feed status no longer flashes back to “Feed normal” while opening or closing the popover; the streaming state remains stable across the popover lifecycle.
+- Share actions now use the system share icon, and share-card footer spacing has been increased for a more balanced export.
+
+For first-time installation, download Pulse-0.3.0.dmg and drag Pulse to Applications. The zip asset is used by Sparkle automatic updates.

--- a/scripts/release-mac.sh
+++ b/scripts/release-mac.sh
@@ -54,6 +54,7 @@ PY
 fi
 BUILD_NUMBER="${PULSE_BUILD_NUMBER:-$(date +%s)}"
 TAG="${PULSE_TAG:-v$VERSION}"
+RELEASE_NOTES_FILE="${PULSE_RELEASE_NOTES_FILE:-$ROOT/release-notes/$VERSION.md}"
 
 BUILD_DIR="$ROOT/build/release"
 ARCHIVE_PATH="$BUILD_DIR/Pulse.xcarchive"
@@ -273,13 +274,20 @@ echo "==> Uploading GitHub Release assets"
 if gh release view "$TAG" --repo "$GH_REPO" >/dev/null 2>&1; then
   gh release upload "$TAG" "$ZIP_PATH" "$DMG_PATH" --repo "$GH_REPO" --clobber
 else
-  gh release create "$TAG" "$ZIP_PATH" "$DMG_PATH" \
-    --repo "$GH_REPO" \
-    --title "Pulse ${VERSION}" \
-    --notes "Pulse ${VERSION}
+  if [[ -f "$RELEASE_NOTES_FILE" ]]; then
+    gh release create "$TAG" "$ZIP_PATH" "$DMG_PATH" \
+      --repo "$GH_REPO" \
+      --title "Pulse ${VERSION}" \
+      --notes-file "$RELEASE_NOTES_FILE"
+  else
+    gh release create "$TAG" "$ZIP_PATH" "$DMG_PATH" \
+      --repo "$GH_REPO" \
+      --title "Pulse ${VERSION}" \
+      --notes "Pulse ${VERSION}
 
 For first-time installation, download Pulse-${VERSION}.dmg and drag Pulse to Applications.
 The zip asset is used by Sparkle automatic updates."
+  fi
 fi
 
 echo "==> Publishing stable Sparkle appcast asset"


### PR DESCRIPTION
## What changed

- adds public-market-data sharing from symbol detail pages
- promotes the watchlist share action to the top-level toolbar
- unifies watchlist, detail, and exported intraday trends on one-minute current-session candles
- stabilizes live-stream status across popover transitions
- improves share iconography and export footer spacing
- bumps Pulse to 0.3.0 and adds release notes used by the release pipeline

## Why

The three trend surfaces previously used different candle periods, x-axis spacing, and fallbacks, so the same symbol could appear to have different momentum. Sharing also required extra navigation and the live status briefly reported the wrong state during popover transitions.

## Validation

- PulseCore: 62 tests passed
- Release configuration build succeeded
- share PNG/TIFF self-test passed
- release script syntax and diff checks passed