### PR TITLE
Sign release disk images before notarization

### DIFF
--- a/scripts/release-mac.sh
+++ b/scripts/release-mac.sh
@@ -246,6 +246,14 @@ mkdir -p "$DMG_STAGE"
 ln -s /Applications "$DMG_STAGE/Applications"
 create_dmg "$DMG_STAGE" "$DMG_PATH" "Pulse"
 
+echo "==> Signing disk image"
+codesign --force \
+  --sign "$APPLE_SIGNING_IDENTITY" \
+  --timestamp \
+  --options runtime \
+  "$DMG_PATH"
+codesign --verify --strict --verbose=2 "$DMG_PATH"
+
 if [[ "${SKIP_NOTARIZE:-0}" != "1" ]]; then
   echo "==> Notarizing disk image"
   xcrun notarytool submit "$DMG_PATH" \


### PR DESCRIPTION
## What changed

The macOS release pipeline now signs the generated DMG with the Developer ID identity and verifies that signature before submitting the disk image for notarization.

## Why

The app bundle was signed and notarized correctly, and the DMG had a valid stapled notarization ticket, but the DMG container itself had no usable signature. Gatekeeper disk-image assessment therefore rejected the first-install artifact.

## Validation

- release script syntax passed
- existing app and DMG stapler tickets validated
- repair path will re-sign, re-notarize, and replace the v0.3.0 DMG in place